### PR TITLE
Extension is unusable with large number of daily activity items

### DIFF
--- a/extension.js
+++ b/extension.js
@@ -103,9 +103,7 @@ HamsterBox.prototype = {
         label.set_text(_("Todays activities"))
         box.add(label);
 
-        let scrollbox = new St.ScrollView({style_class: 'hamster-scrollbox',
-                                           'hscrollbar-policy': Gtk.PolicyType.NEVER,
-                                           'vscrollbar-policy': Gtk.PolicyType.AUTOMATIC});
+        let scrollbox = new St.ScrollView({style_class: 'hamster-scrollbox'});
         box.add(scrollbox);
 
         // Since St.Table does not implement StScrollable, we create a

--- a/stylesheet.css
+++ b/stylesheet.css
@@ -14,6 +14,8 @@
 
 .hamster-scrollbox {
     max-height: 200px;
+    overflow-x: none;
+    overflow-y: auto;
 }
 
 .cell-label {


### PR DESCRIPTION
If you create a large number of activities in one day, the "Today's Activities" pane extends past the bottom of the screen. This makes it extremely difficult to use the extension to stop tracking activities, to pull up the overview, or to edit the most recent activities.

![screenshot](http://i.imgur.com/tLk85.png)
