### PR TITLE
Add support for Gnome 3.6. Fixes #43.

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -8,7 +8,7 @@
     ],
     "settings-schema": "org.gnome.shell.extensions.project-hamster",
     "shell-version": [
-        "3.4"
+        "3.4", "3.6"
     ],
     "url": "https://github.com/tbaugis/hamster-shell-extension",
     "uuid": "hamster@projecthamster.wordpress.com",


### PR DESCRIPTION
- Add support for 3.6 in metadata.json.
- Change symbolic icon support.
- Updates to new way of adding items to panel.
