### PR TITLE
Fix typo in czech locales

### DIFF
--- a/locale/cs/LC_MESSAGES/hamster-shell-extension.po
+++ b/locale/cs/LC_MESSAGES/hamster-shell-extension.po
@@ -40,7 +40,7 @@ msgstr "Zastavit sledování"
 
 #: extension.js:249
 msgid "Tracking Settings"
-msgstr "Nastevení sledování"
+msgstr "Nastavení sledování"
 
 #: extension.js:398
 msgid "No activity"


### PR DESCRIPTION
Hi guys,

There is a typo in Tracking Settings translation. Please let me know how to recreate the binary file (if it's necessarily).

Kind regards,
Lukáš
