### PR TITLE
Bugfix: Only copy tags when they're present

### DIFF
--- a/extension.js
+++ b/extension.js
@@ -408,7 +408,7 @@ HamsterExtension.prototype = {
                     let factStr = button.fact.name
                                   + "@" + button.fact.category
                                   + ", " + (button.fact.description);
-                    if (button.fact.tags) {
+                    if (button.fact.tags.length) {
                         factStr += " #" + button.fact.tags.join(", #");
                     }
 


### PR DESCRIPTION
When copying a task with no tags, a superfluous `#` was appended to the description.
