### PR TITLE
Update to Gnome 3.16 API

### DIFF
--- a/extension.js
+++ b/extension.js
@@ -545,7 +545,8 @@ function ExtensionController(extensionMeta) {
             Main.wm.addKeybinding("show-hamster-dropdown",
                 this.extension._settings,
                 Meta.KeyBindingFlags.NONE,
-                Shell.ActionMode.ALL,
+                //since Gnome 3.16, Shell.KeyBindingMode is replaced by Shell.ActionMode
+                Shell.KeyBindingMode ? Shell.KeyBindingMode.ALL : Shell.ActionMode.ALL,
                 Lang.bind(this.extension, this.extension.toggle)
             );
         },

--- a/extension.js
+++ b/extension.js
@@ -545,7 +545,7 @@ function ExtensionController(extensionMeta) {
             Main.wm.addKeybinding("show-hamster-dropdown",
                 this.extension._settings,
                 Meta.KeyBindingFlags.NONE,
-                Shell.KeyBindingMode.ALL,
+                Shell.ActionMode.ALL,
                 Lang.bind(this.extension, this.extension.toggle)
             );
         },


### PR DESCRIPTION
In Gnome 3.16, the extension actually loads with an error because the API changed from Shell.KeyBindingMode to Shell.ActionMode.

This fixes it.