### PR TITLE
[#117] Switch to semantic versioning

### DIFF
--- a/extension/metadata.json
+++ b/extension/metadata.json
@@ -18,5 +18,5 @@
     ],
     "url": "https://github.com/projecthamster/shell-extension.git",
     "uuid": "hamster@projecthamster.wordpress.com",
-    "version": 22
+    "version": 0.10.0
 }


### PR DESCRIPTION
Instead of an incrementing build number we use [semantic
versioning](http://semver.org) from now on. Starting at ``0.10.0``.
As far as I am able to figure from the non existing documentation of
``metadata.json`` keys there are no particular contrains on the version
string, so this switch should be trivial.

Closes: #117