### PR TITLE
[#127] Add Contibutor listing

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -1,2 +1,42 @@
 Credits
 =======
+
+Development Lead
+----------------
+
+* Eric Goller <eric.goller@ninjaduck.solutions>
+
+Contributors
+------------
+
+Original Authors (pre 0.10.0)
+------------------------------
+* Tom Baugis <toms.baugis@gmail.com>
+* Jérôme Oufella <jerome@oufella.com>
+* Markus Koller <markus-koller@gmx.ch>
+
+
+Original Contributors (pre 0.10.0)
+-----------------------------------
+
+* Piotr Plenik
+* dougle (github: @dougle)
+* Alexander Hofbauer
+* Martey Dodoo
+* Andrew Stubbs
+* Larissa Reis <reiss.larissa@gmail.com>
+* Aleksei Lissitsin
+* udarnik386 (github: @udarnik386)
+* Matías Croce
+* msize (guthub: @msize)
+* Stephen White
+* Martin Mlynář <nexus@smoula.net>
+* Matt Molyneaux <moggers87@moggers87.co.uk>
+* Raphaël Doursenaud <raphael@doursenaud.fr>
+* Gregory DK
+* juanmah (githu: @juanmah)
+* Daniel Doblado <danieldoblado@gmail.com>
+* WBTMagnum (github: @WBTMagnum)
+* fosero (guthub: @fosero)
+* Boris (github: @bwcknr)
+* Lukáš Doktor <ldoktor@redhat.com>


### PR DESCRIPTION
This PR adds a listing of all contributors so far. Future contributors should add themselfs here, which should be pointed out in the *contribution guidelines*.

We separated contributors up to today as 'original authors/contributors' in order to provide a clear cut for any potential upcoming refactoring that may be required and to be as transparent as possible.

Closes: #127