### PR TITLE
[133] Provide Basic Documentation

### DIFF
--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -1,7 +1,6 @@
 ============
 Contributing
 ============
-
 Contributions are welcome, and they are greatly appreciated! Every
 little bit helps, and credit will always be given.
 
@@ -12,50 +11,49 @@ Types of Contributions
 
 Report Bugs
 ~~~~~~~~~~~
-
-Report bugs at https://github.com/projecthamster/shell-extension/issues/
+Report bugs at the
+`issue tracker <https://github.com/projecthamster/shell-extension/issues/>`_.
 
 If you are reporting a bug, please include:
 
-* Your operating system name and version.
-* Any details about your local setup that might be helpful in troubleshooting.
-* Detailed steps to reproduce the bug.
+- Your operating system name and version.
+- Any details about your local setup that might be helpful in troubleshooting.
+- Detailed steps to reproduce the bug.
 
 Fix Bugs
 ~~~~~~~~
-
 Look through the GitHub issues for bugs. Anything tagged with "bug"
 is open to whoever wants to implement it.
 
 Implement Features
 ~~~~~~~~~~~~~~~~~~
-
-Look through the GitHub issues for features. Anything tagged with "feature"
-is open to whoever wants to implement it.
+Look through the GitHub issues for features.
 
 Write Documentation
 ~~~~~~~~~~~~~~~~~~~
-
-*Hamster-Shell-Extension* could always use more documentation, whether as part of the
-official  docs, in docstrings, or even on the web in blog posts,
+*Hamster-Shell-Extension* could always use more documentation, whether as part
+of the official  docs, in docstrings, or even on the web in blog posts,
 articles, and such.
 
 Submit Feedback
 ~~~~~~~~~~~~~~~
-
-The best way to send feedback is to file an issue at https://github.com/projecthamster/shell-extension/issues.
+The best way to send feedback is to 
+`file an issue <https://github.com/projecthamster/shell-extension/issues>`_.
 
 If you are proposing a feature:
 
-* Explain in detail how it would work.
-* Keep the scope as narrow as possible, to make it easier to implement.
-* Remember that this is a volunteer-driven project, and that contributions
+- Explain in detail how it would work.
+- Keep the scope as narrow as possible, to make it easier to implement.
+- Remember that this is a volunteer-driven project, and that contributions
   are welcome :)
 
 Get Started!
 ------------
+Ready to contribute? Here's how to set up `hamster-shell-extension` for local
+development.
 
-Ready to contribute? Here's how to set up `hamster-shell-extension` for local development.
+For additional information on coding conventions and commit/PR best practices
+please refer to the :doc:`styleguide <styleguide>`.
 
 #. Fork `the repository <https://github.com/projecthamster/shell-extension/>`_
    on github.
@@ -75,8 +73,9 @@ Ready to contribute? Here's how to set up `hamster-shell-extension` for local de
     $ git commit -m "Your detailed description of your changes."
     $ git push origin name-of-your-bugfix-or-feature
 
-#. Submit a `Pull Request <https://github.com/projecthamster/shell-extension/pulls>`_
-    with your branch.
+#. Submit a `Pull Request
+   <https://github.com/projecthamster/shell-extension/pulls>`_ with your
+   branch.
 
 Pull Request Guidelines
 -----------------------

--- a/README.rst
+++ b/README.rst
@@ -12,6 +12,15 @@ Thank you Frederic!
 Install
 --------
 
+Dependencies
+~~~~~~~~~~~~
+Because *Hamster-Shell-Extension* is just a frontend to the hamster dbus
+service the presence of `hamster-time-tracker
+<https://github.com/projecthamster/hamster>`_ is required. You can verify that
+the relevant dbus services are up and running by issuing ``ps aux | grep
+hamster`` which should bring up ``hamster-service`` and
+``hamster-windows-service``.
+
 Install For Production
 ~~~~~~~~~~~~~~~~~~~~~~~
 The extension is available on `the central extension repository <https://extensions.gnome.org/extension/425/project-hamster-extension>`_.

--- a/docs/hacking.rst
+++ b/docs/hacking.rst
@@ -1,0 +1,29 @@
+Hacking
+========
+
+One of the great challenges developing or contributing to a *GNOME-Shell*
+extension is the lack of documentation for it.
+In order to be as inviting as possible and to allow you to get hacking on
+*Hamster-Shell-Extension* without dwelling all to deep in the muddy waters of
+*GNOME-Shell* development we aim to do two things.
+
+#. Highlight those parts of the code that are closely coupled with specific
+   parts of the *GNOME-Shell* framework. This way you have a good idea if there
+   are hidden constrains to be considered or if "what you see is what you get".
+#. Provide some references and bits and pieces about various aspects of 
+   *GNOME-Shell* development in general. This is particularly helpful if you
+   actually need to interact with the shell framework to get you work done.
+
+References
+-----------
+- `GNOME's own entry point for extension development <https://wiki.gnome.org/Projects/GnomeShell/Extensions>`_
+- `Notes on i18n and preferences dialog <https://iacopodeenosee.wordpress.com/2013/03/10/simple-guide-to-improve-your-own-extension-on-gnome-shell/>`_.
+- `UUID Guidelines <https://wiki.gnome.org/Projects/GnomeShell/Extensions/UUIDGuidelines>`_
+- `GJS <https://wiki.gnome.org/action/show/Projects/Gjs?action=show&redirect=Gjs>`_: Javascript Bindings for *GNOME*. This also mentions the possibility of tests.
+- `A non trivial introduction <http://mathematicalcoffee.blogspot.de/2012/09/gnome-shell-extensions-getting-started.html>`_ by mathematicalcoffee which
+  also explains some of the mandatory and optional bits and pieces.
+- The closest to a practical `API Reference <http://mathematicalcoffee.blogspot.de/2012/09/gnome-shell-javascript-source.html>`_
+  I could find. While not perfect it provides a most useful starting point if you know what kind of widget/feature you want
+  but not where to find it. Or of cause, if you want to know where to find out more about this obscure 
+  line of code you just stumbled upon.
+- `Additional information <https://wiki.gnome.org/Projects/GnomeShell/Extensions/FAQ/CreatingExtensions>`_ on i18n and multi-file extensions

--- a/docs/hacking.rst
+++ b/docs/hacking.rst
@@ -10,7 +10,7 @@ In order to be as inviting as possible and to allow you to get hacking on
 #. Highlight those parts of the code that are closely coupled with specific
    parts of the *GNOME-Shell* framework. This way you have a good idea if there
    are hidden constrains to be considered or if "what you see is what you get".
-#. Provide some references and bits and pieces about various aspects of 
+#. Provide some references and bits and pieces about various aspects of
    *GNOME-Shell* development in general. This is particularly helpful if you
    actually need to interact with the shell framework to get you work done.
 
@@ -24,6 +24,9 @@ References
   also explains some of the mandatory and optional bits and pieces.
 - The closest to a practical `API Reference <http://mathematicalcoffee.blogspot.de/2012/09/gnome-shell-javascript-source.html>`_
   I could find. While not perfect it provides a most useful starting point if you know what kind of widget/feature you want
-  but not where to find it. Or of cause, if you want to know where to find out more about this obscure 
+  but not where to find it. Or of cause, if you want to know where to find out more about this obscure
   line of code you just stumbled upon.
 - `Additional information <https://wiki.gnome.org/Projects/GnomeShell/Extensions/FAQ/CreatingExtensions>`_ on i18n and multi-file extensions
+- Information on current `dbus best practices <https://mail.gnome.org/archives/gnome-shell-list/2013-February/msg00059.html>`_.
+  This is particular usefull as it mentions that ``Sync`` and ``Remote`` strings are appended to our interface method names. For a full tutorial
+  please `see refer to this one <http://cheesehead-techblog.blogspot.de/2012/08/dbus-tutorial-introspection-figuring.html>`_.

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -6,14 +6,21 @@
 Welcome to Hamster-Shell-Extension's documentation!
 ====================================================
 
-Contents:
+This documentation tries to help you use, improve and get involved with the
+*Hamster-Shell-Extension*.
+
+As always: please feel encourage to summit an issue or PR if you spot an error
+or feel that topics are not covered properly.
 
 .. toctree::
    :maxdepth: 2
+   :hidden:
 
    readme
    contributing
    authors
+   hacking
    history
    packaging
    versioning
+   styleguide

--- a/docs/packaging.rst
+++ b/docs/packaging.rst
@@ -1,9 +1,68 @@
 Packaging / Release Process
 ============================
+Here we document the packaging and release process.
+This will most likely be of no interest to you, but is done for transparency
+and internal documentation.
 
+Instead of having to go through the process manually we provide convenient make
+targets for its individual steps as well as for the whole process (``make
+dist``).
+
+TL;DR
+--------
 #. Bump version: ``bumpversion [minor, patch]``
 #. Check and if needed bump Gnome Shell compatibility in ``metadata.json``.
 #. Commit your changes and run ``make dist``.
 #. Go to ``https://extensions.gnome.org/upload/`` and upload the generated file
    ``hamster@projecthamster.wordpress.com.zip``.
 #. You can check the review progress at ``https://extensions.gnome.org/review/``.
+
+Long Version
+-------------
+GNOME-Shell extensions require at lest an ``extension.js`` as well as a
+``metadata.json`` file in their root directory. Besides other auxillary files
+we opt to add ``prefs.js`` and a ``stylesheet.css`` as optional files that are
+(if used) expected to have those names and be placed at the root directory as
+well.
+All actual source code is placed in the ``/extensions`` directory of the main
+repository.
+
+File Location / Directory Structure
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Besides the actual source code, our project makes use of addition non-code
+resources. In particular: Icon image files and ``gettext`` translations. All
+these resources are organized in a separate ``/data`` directory of the root
+repository.
+Whilst this structure make for a clean and simple organization of our codebase
+to work on, it is unfit to be used as a working *extension*. This requires some
+addition packaging.
+
+Collect and Compile
+~~~~~~~~~~~~~~~~~~~~~
+In order for GNOME-Shell to accept our extension properly two additional things
+need to happen.
+
+#. We need to place the content of the ``data`` directory within the ``extension``
+   directory (e.g. on the same level as ``extension.js``.
+#. We need to compile the GSettings schema as well as gettext ``.po`` files so
+   as it actually their binary versions ``gschemas.compiled`` and ``*.mo`` files
+   that we deploy.
+
+In order not to mess with our existing clean structure, all this collecting and
+compiling happens in a dedicated build directory which is not part of the
+project repository.
+
+Packaging
+~~~~~~~~~~
+Now that our build directory contains all required files in state expected by
+GNOME-shell all that is left to do is to warp it up in a convenient easy to
+deploy way.  There are two relevant ways to deploy an extension.
+
+#. Via the official `gnome extensions repository <https://extensions.gnome.org>`_.
+#. Copying/symlinking the contend of the build directory to 
+   ``~/.local/share/gnome-shell/extension/hamster@projecthamster.wordpreess.com``
+
+In order to upload our release to ``extensions.gnome.org`` we wrap the build
+directory in a zip file while we also provide a separate tarball of the same
+content which can easily be used to copy/symlink its content in the
+aforementioned way.

--- a/docs/styleguide.rst
+++ b/docs/styleguide.rst
@@ -1,0 +1,87 @@
+Style Guide
+============
+
+General
+--------
+- Try to stick to 79 chars. When this is not enough you may use up to 99 chars.
+  This is more tolerable for code than for documentation.
+
+Code-style
+--------------
+- Like the *GNOME-Shell* project we follow the `GJS coding style
+  <https://wiki.gnome.org/Projects/GnomeShell/Gjs_StyleGuide>`_ which in short
+  is: indent 4 spaces, no tabs, spaces after comma, no space after function
+  call (Emacs mode line for this: 
+  ``/* -*- mode: js2; js2-basic-offset: 4; indent-tabs-mode: nil -*- */``.
+- Imports should be at the top, in two groups, one for standard imports (like
+  ``imports.lang`` or ``imports.dbus``) and introspection, the other for Shell
+  API.  Within the same group, put everything in alphabetic order.
+- Readability trumps almost anything. Readable and approachable code carries
+  it's weight as a lower contribution-barrier, less bugs and easier
+  debugging.  Having a particular clever, aka dense, alternative is rarely
+  warranted.
+- Favour multiple small specialized (local) functions/methods over big
+  all-encompassing ones.
+- Use well established and maintained high quality 3rd party libraries over own
+  implementations.
+- Use expressive variable names. If you have to trade off verbosity and 
+  expressiveness, go for the later.
+- Assigning variables even if they are used only once can be preferable if
+  expressions become clearer and less dense.
+
+Documentation
+---------------
+- We use `JSDoc syntax and blog tags <http://usejsdoc.org>`_ to document all
+  our code.
+- Headings should capitalise each word.
+- Please use ``-`` for unordered lists and ``#.`` for ordered lists unless you
+  really want to enforce a certain numbering.
+- No blank lines after headings. 
+
+Committing and commit messages
+------------------------------
+- Commit one change/feature at a time (you can use `tig <http://jonas.nitro.dk/tig/>`_
+  to select the changes you want to commit).
+- Separate bug fixes from feature changes, bugfixes may need to be backported
+  to the stable branch.
+- Maximum line length is 50 characters for the first line and 72 for all
+  following lines.
+- The first line is a short summary, no trailing period.
+- Leave a blank line between the summary and the body of the commit message.
+- Explain what you did and add all relevant information to the commit message.
+- If an issue exists for your feature/bug/task add it to the end of the commit
+  message. If your commit implements a feature use the ``closes`` keyword, if
+  it fixes a bug use ``fixes``.
+
+Rebasing
+--------
+- Try to rebase to keep the commit history linear::
+
+    $ git pull --rebase
+
+- If you have uncommitted changes in your working directory use ``git stash``
+  to stash the changes while rebasing::
+
+    $ git stash
+    $ git pull --rebase
+    $ git stash pop
+
+- Before you prepare your Pull Request, please squash (``git rebase -i
+  HEAD~XXX``) any commits that really belong to one functional unit. It is
+  perfectly fine (and preferable) if your PR has multiple modular and distinct
+  commits though.
+
+- **Do not** rebase already published changesets!
+
+Pull Requests
+-------------
+The title of a pull request should contain a summary of the issue it is related
+to, as well as the prepended issue id in square brackets. An example would look like
+``[#23] Advanced report options``. This way, a link between the PR and the
+issue will be created.
+Each PR that is not absolutly non-trivial should include at least a very short
+description on what is done and why. Just imagine the kind of info you would
+look for in you dig it up in 12 month time.
+
+Every pull request has to be approved by at least one other developer before
+merging.

--- a/docs/versioning.rst
+++ b/docs/versioning.rst
@@ -1,10 +1,23 @@
 Versioning
 ===========
-
 ``hamster-shell-extension`` follows the `semantic versioning <http://semver.org>`_ scheme.
 Each release is packaged and uploaded to the
 `gnome extensions repository <https://extensions.gnome.org/extension/425/project-hamster-extension/>`_.
 As this repository does not allow listing of multiple versions of the same
-extension we will allways provide the latest stable release.  If you need a
+extension we will always provide the latest stable release.  If you need a
 different version, please check out the master branch on github. We provide
-tags for all releases as well as convinient tarballs for manual installation.
+tags for all releases as well as convenient tarballs for manual installation.
+
+All current (pre 1.0) versions are targeted towards usage with ``hamter-time-tracker``
+(aka ``legacy hamster``). Upcoming support for the rewritten codebase (``hamster-lib`` and
+friends) will be indicated by the ``1.0.0`` version. The goal for our work on the ``0.*.*``
+releases is to bring the repository/project up to standards with the rest of the project
+in terms of documentation, tests and general infrastructure.
+
+About Previous Versioning
+--------------------------
+Before version 0.10.0 *Hamster-Shell-Extension* used to handle versioning by
+carrying a incrementing *build number*. In addition to that, *git tags* were
+used on github (as releases) that indicate the (highest compatible) GNOME-Shell
+version targeted by this release. Which actually is meta information and should
+not be part of the versioning at all.


### PR DESCRIPTION
This PR expands what little documentation we already had and adds several new pages to help potential contributors to get a quick overview about how things work as well as to codify best practices via the *Styleguide*.

I opted to use a single commit for each documentation page to be more verbose and transparent. If you @border0464111 feel that this is too much, please let me know.