### PR TITLE
Extension configuration : add an option 'center' in "Positioning" configuration (without replacing the calendar)

### DIFF
--- a/extension/extension.js
+++ b/extension/extension.js
@@ -249,6 +249,9 @@ function Controller(extensionMeta) {
                 this._activitiesText = activitiesMenu.get_text();
                 activitiesMenu.set_text('');
                 Main.panel.addToStatusArea("hamster", this.panelWidget, 1, "left");
+            } else if (placement == 3) {
+                // 'Center'
+                Main.panel.addToStatusArea("hamster", this.panelWidget, 1, "center");
             } else {
                 // 'Default'
                 Main.panel.addToStatusArea("hamster", this.panelWidget, 0, "right");

--- a/extension/prefs.js
+++ b/extension/prefs.js
@@ -59,6 +59,7 @@ const HamsterSettingsWidget = new GObject.Class({
         placementOptions.set(placementOptions.append(), [0, 1], ["Default", 0]);
         placementOptions.set(placementOptions.append(), [0, 1], ["Replace calendar", 1]);
         placementOptions.set(placementOptions.append(), [0, 1], ["Replace activities", 2]);
+        placementOptions.set(placementOptions.append(), [0, 1], ["Center", 3]);
 
         let placementCombo = new Gtk.ComboBox({model: placementOptions});
 


### PR DESCRIPTION
In the _gnome shell extension_ configuration panel, a new option has been added to the _Positioning_ select : **center**, which displays the extension at the center of the _Gnome top menu bar_, and this, without replacing the _calendar_. Extension is displayed on its right.