### PR TITLE
Claim GNOME Shell 3.30 as supported version

### DIFF
--- a/data/metadata.json
+++ b/data/metadata.json
@@ -19,7 +19,8 @@
         "3.22",
         "3.24",
         "3.26",
-        "3.28"
+        "3.28",
+        "3.30"
     ],
     "url": "https://github.com/projecthamster/hamster-shell-extension.git",
     "uuid": "contact@projecthamster.org",


### PR DESCRIPTION
Hi,

I'm using Hamster shell extension on 3.30 (Debian Buster). It works well :

- [x] Auto-create an activity tag
- [x] Start activity
- [x] Stop activity
- [x] Resume activity
- [x] Edit activity
- [x] Open summary
