### PR TITLE
Gnome shell 3.30 compatibility

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -52,11 +52,15 @@ clean-docs:
 clean-test-docs:
 	$(MAKE) -C docs clean SPHINX_BUILDDIR=$(SPHINX_TEST_SPHINX_BUILDDIR)
 
-collect:
-	mkdir -p $(BUILDDIR)
+$(BUILDDIR):
+	mkdir -p $@
+
+$(BUILDDIR)/convenience.js:	$(BUILDDIR)
+	wget https://gitlab.gnome.org/GNOME/gnome-shell-extensions/raw/gnome-3-30/lib/convenience.js -O $@
+
+collect:	$(BUILDDIR)/convenience.js
 	cp -R extension/* $(BUILDDIR)
 	cp -R data/* $(BUILDDIR)
-	wget https://gitlab.gnome.org/GNOME/gnome-shell-extensions/raw/gnome-3-30/lib/convenience.js -O $(BUILDDIR)/convenience.js
 
 compile: collect
 	glib-compile-schemas $(BUILDDIR)/schemas
@@ -71,7 +75,7 @@ develop:
 	pip install -U pip setuptools wheel
 	pip install -U -r requirements.pip
 
-dist: clean-build compile
+dist: compile
 # We need to do this like this as 'zip' always uses the cwd as archive root.
 # And for the extension to work extension.js etc. need to be at the root.
 	mkdir -p $(DISTDIR);

--- a/Makefile
+++ b/Makefile
@@ -56,7 +56,7 @@ collect:
 	mkdir -p $(BUILDDIR)
 	cp -R extension/* $(BUILDDIR)
 	cp -R data/* $(BUILDDIR)
-	wget https://gitlab.gnome.org/GNOME/gnome-shell-extensions/raw/master/lib/convenience.js -O $(BUILDDIR)/convenience.js
+	wget https://gitlab.gnome.org/GNOME/gnome-shell-extensions/raw/gnome-3-30/lib/convenience.js -O $(BUILDDIR)/convenience.js
 
 compile: collect
 	glib-compile-schemas $(BUILDDIR)/schemas

--- a/data/metadata.json
+++ b/data/metadata.json
@@ -19,7 +19,8 @@
         "3.22",
         "3.24",
         "3.26",
-        "3.28"
+        "3.28",
+        "3.30"
     ],
     "url": "https://github.com/projecthamster/hamster-shell-extension.git",
     "uuid": "contact@projecthamster.org",

--- a/extension/extension.js
+++ b/extension/extension.js
@@ -193,8 +193,6 @@ function Controller(extensionMeta) {
             global.log('Shutting down hamster-shell-extension.');
             this._removeWidget(this.placement);
             Main.panel.menuManager.removeMenu(this.panelWidget.menu);
-            GLib.source_remove(this.panelWidget.timeout);
-            this.panelWidget.actor.destroy();
             this.panelWidget.destroy();
             this.panelWidget = null;
             this.apiProxy = null;

--- a/extension/extension.js
+++ b/extension/extension.js
@@ -174,7 +174,7 @@ function Controller(extensionMeta) {
                 windowsProxy_vanished_callback.bind(this));
 
             this.apiProxy.connectSignal('ActivitiesChanged', Lang.bind(this, this.refreshActivities));
-            this.activities = this.refreshActivities();
+            this.refreshActivities();
 
             Main.panel.menuManager.addMenu(this.panelWidget.menu);
             Main.wm.addKeybinding("show-hamster-dropdown",
@@ -218,15 +218,11 @@ function Controller(extensionMeta) {
                 controller.apiProxy.GetActivitiesRemote("", Lang.bind(this, function([response], err) {
                   controller.runningActivitiesQuery = false;
                   controller.activities = response;
+                  global.log('ACTIVITIES HAMSTER: ', controller.activities);
                 }));
-
-                global.log('ACTIVITIES HAMSTER: ', controller.activities);
-                return controller.activities;
             }
 
-            let result = getActivities(this);
-            this.activities = result;
-            return result;
+            getActivities(this);
         },
 
         /**


### PR DESCRIPTION
- Fix corrupting Gnome Shell 3.30 lock functionality
- Remove some warnings
