### PR TITLE
Update for convenience.js again

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -56,7 +56,7 @@ collect:
 	mkdir -p $(BUILDDIR)
 	cp -R extension/* $(BUILDDIR)
 	cp -R data/* $(BUILDDIR)
-	wget https://gitlab.gnome.org/GNOME/gnome-shell-extensions/raw/master/lib/convenience.js -O $(BUILDDIR)/convenience.js
+	wget https://gitlab.gnome.org/GNOME/gnome-shell-extensions/raw/3.29.91/lib/convenience.js -O $(BUILDDIR)/convenience.js
 
 compile: collect
 	glib-compile-schemas $(BUILDDIR)/schemas

--- a/README.rst
+++ b/README.rst
@@ -33,7 +33,7 @@ Install For Production
 ~~~~~~~~~~~~~~~~~~~~~~~
 The extension is available on `the central extension repository <https://extensions.gnome.org/extension/425/project-hamster-extension>`_.
 
-Current compatible Gnome shell version: 3.28
+Current compatible Gnome shell version: 3.30
 For previous shell versions check `releases <https://github.com/projecthamster/hamster-shell-extension/tags>`_.
 
 Creating a development environment


### PR DESCRIPTION
Similar to #216.
In my quest to run the extension on gnome-shell 3.30 in a Fedora 29 box, I followed the instructions on [README](/projecthamster/hamster-shell-extension/blob/develop/README.rst#manual-installation-for-testing-and-development), but they do not seem to be up to date:
```(.venv) [hamster-shell-extension]$ make dist
rm -fr build
mkdir -p build
cp -R extension/* build
cp -R data/* build
wget https://gitlab.gnome.org/GNOME/gnome-shell-extensions/raw/master/lib/convenience.js -O build/convenience.js
--2019-02-10 17:53:53--  https://gitlab.gnome.org/GNOME/gnome-shell-extensions/raw/master/lib/convenience.js
Resolving gitlab.gnome.org (gitlab.gnome.org)... 209.132.180.181
Connecting to gitlab.gnome.org (gitlab.gnome.org)|209.132.180.181|:443... connected.
HTTP request sent, awaiting response... 404 Not Found
2019-02-10 17:53:54 ERROR 404: Not Found.
``` 

I tried to find the file in gnome gitlab, but had no success, so I used the last known tag with it, and the compilation went fine. 

However, as I am using it for the first time, and I don't see any text or icon appear in the gnome top panel. Can I help to debug this further? I installed `hamster`, and it works fine otherwise. 

PS: I also noticed that the installation instructions need and update, but I will come back to that (make a pull request with updated  #instructions) later, when working on 3.30 is confirmed. (Check my clone on gitlab, if you are impatient.)
