### PR TITLE
Make code compatible with gnome-shell 3.32

### DIFF
--- a/.jshint.cfg
+++ b/.jshint.cfg
@@ -1,3 +1,4 @@
 {
-  "moz": true
+  "moz": true,
+  "esversion": 6
 }

--- a/Makefile
+++ b/Makefile
@@ -56,7 +56,6 @@ collect:
 	mkdir -p $(BUILDDIR)
 	cp -R extension/* $(BUILDDIR)
 	cp -R data/* $(BUILDDIR)
-	wget https://gitlab.gnome.org/GNOME/gnome-shell-extensions/raw/master/lib/convenience.js -O $(BUILDDIR)/convenience.js
 
 compile: collect
 	glib-compile-schemas $(BUILDDIR)/schemas

--- a/data/metadata.json
+++ b/data/metadata.json
@@ -10,16 +10,8 @@
     "gettext-domain": "hamster-shell-extension",
     "settings-schema": "org.gnome.shell.extensions.project-hamster",
     "shell-version": [
-        "3.10",
-        "3.12",
-        "3.14",
-        "3.16",
-        "3.18",
-        "3.20",
-        "3.22",
-        "3.24",
-        "3.26",
-        "3.28"
+        "3.30",
+        "3.32"
     ],
     "url": "https://github.com/projecthamster/hamster-shell-extension.git",
     "uuid": "contact@projecthamster.org",

--- a/extension/extension.js
+++ b/extension/extension.js
@@ -173,7 +173,7 @@ class Controller {
             windowsProxy_vanished_callback.bind(this));
 
         this.apiProxy.connectSignal('ActivitiesChanged', this.refreshActivities.bind(this));
-        this.activities = this.refreshActivities();
+        this.refreshActivities();
 
         Main.panel.menuManager.addMenu(this.panelWidget.menu);
         Main.wm.addKeybinding("show-hamster-dropdown",
@@ -204,26 +204,16 @@ class Controller {
      * Build a new cache of all activities present in the backend.
      */
     refreshActivities() {
-        /**
-         * Return an Array of [Activity.name, Activity.category.name] Arrays.
-         *
-         */
-        let result = () => {
-            if (this.runningActivitiesQuery) {
-                return(this.activities);
-            }
+        if (this.runningActivitiesQuery) {
+            return(this.activities);
+        }
 
-            this.runningActivitiesQuery = true;
-            this.apiProxy.GetActivitiesRemote("", ([response], err) => {
-              this.runningActivitiesQuery = false;
-              this.activities = response;
-            });
-
+        this.runningActivitiesQuery = true;
+        this.apiProxy.GetActivitiesRemote("", ([response], err) => {
+            this.runningActivitiesQuery = false;
+            this.activities = response;
             global.log('ACTIVITIES HAMSTER: ', this.activities);
-            return this.activities;
-        };
-        this.activities = result;
-        return result;
+        });
     }
 
     /**

--- a/extension/extension.js
+++ b/extension/extension.js
@@ -192,8 +192,6 @@ class Controller {
         global.log('Shutting down hamster-shell-extension.');
         this._removeWidget(this.placement);
         Main.panel.menuManager.removeMenu(this.panelWidget.menu);
-        GLib.source_remove(this.panelWidget.timeout);
-        this.panelWidget.actor.destroy();
         this.panelWidget.destroy();
         this.panelWidget = null;
         this.apiProxy = null;

--- a/extension/prefs.js
+++ b/extension/prefs.js
@@ -25,23 +25,21 @@ const Gdk = imports.gi.Gdk;
 const Gio = imports.gi.Gio;
 const Gtk = imports.gi.Gtk;
 const GObject = imports.gi.GObject;
-const Lang = imports.lang;
 
 
 const ExtensionUtils = imports.misc.extensionUtils;
 const Me = ExtensionUtils.getCurrentExtension();
-const Convenience = Me.imports.convenience;
 
-const HamsterSettingsWidget = new GObject.Class({
-    Name: 'ProjectHamster.Prefs.HamsterSettingsWidget',
-    GTypeName: 'HamsterSettingsWidget',
-    Extends: Gtk.VBox,
+const HamsterSettingsWidget = GObject.registerClass(
+class HamsterSettingsWidget extends Gtk.VBox {
+    _init(params) {
+        super._init(params);
 
-    _init : function(params) {
-        this.parent(params);
+        this.name = 'ProjectHamster.Prefs.HamsterSettingsWidget';
+
         this.margin = 10;
 
-        this._settings = Convenience.getSettings();
+        this._settings = ExtensionUtils.getSettings();
 
         let vbox, label;
 
@@ -65,7 +63,7 @@ const HamsterSettingsWidget = new GObject.Class({
         let placementComboRenderer = new Gtk.CellRendererText();
         placementCombo.pack_start(placementComboRenderer, true);
         placementCombo.add_attribute(placementComboRenderer, 'text', 0);
-        placementCombo.connect('changed', Lang.bind(this, this._onPlacementChange));
+        placementCombo.connect('changed', this._onPlacementChange.bind(this));
         placementCombo.set_active(this._settings.get_int("panel-placement"));
 
         vbox.add(placementCombo);
@@ -90,7 +88,7 @@ const HamsterSettingsWidget = new GObject.Class({
         let appearanceComboRenderer = new Gtk.CellRendererText();
         appearanceCombo.pack_start(appearanceComboRenderer, true);
         appearanceCombo.add_attribute(appearanceComboRenderer, 'text', 0);
-        appearanceCombo.connect('changed', Lang.bind(this, this._onAppearanceChange));
+        appearanceCombo.connect('changed', this._onAppearanceChange.bind(this));
         appearanceCombo.set_active(this._settings.get_int("panel-appearance"));
 
         vbox.add(appearanceCombo);
@@ -107,7 +105,7 @@ const HamsterSettingsWidget = new GObject.Class({
                                    margin_top: 5,
                                    text: this._settings.get_strv("show-hamster-dropdown")[0]});
         vbox.add(entry);
-        entry.connect('changed', Lang.bind(this, this._onHotkeyChange));
+        entry.connect('changed', this._onHotkeyChange.bind(this));
 
         vbox.add(new Gtk.Label({label: "Reload gnome shell after updating prefs (alt+f2 > r)",
                                 margin_top: 70}));
@@ -115,9 +113,9 @@ const HamsterSettingsWidget = new GObject.Class({
         let version_text = ExtensionUtils.getCurrentExtension().metadata.version;
         let version_label_text = "You are running hamster-shell-extension version " + version_text;
         vbox.add(new Gtk.Label({label: version_label_text, margin_top: 10}));
-    },
+    }
 
-    _onPlacementChange: function(widget) {
+    _onPlacementChange(widget) {
         let [success, iter] = widget.get_active_iter();
         if (!success)
             return;
@@ -128,9 +126,9 @@ const HamsterSettingsWidget = new GObject.Class({
             return;
 
         this._settings.set_int("panel-placement", newPlacement);
-    },
+    }
 
-    _onAppearanceChange: function(widget) {
+    _onAppearanceChange(widget) {
         let [success, iter] = widget.get_active_iter();
         if (!success)
             return;
@@ -141,9 +139,9 @@ const HamsterSettingsWidget = new GObject.Class({
             return;
 
         this._settings.set_int("panel-appearance", newAppearance);
-    },
+    }
 
-    _onHotkeyChange: function(widget, bananas) {
+    _onHotkeyChange(widget, bananas) {
         //global.log(widget, bananas);
         let hotkey = widget.get_text();
         let [key, mods] = Gtk.accelerator_parse(hotkey);

--- a/extension/widgets/categoryTotalsWidget.js
+++ b/extension/widgets/categoryTotalsWidget.js
@@ -21,10 +21,10 @@ Copyright (c) 2016 - 2018 Eric Goller / projecthamster <elbenfreund@projecthamst
 */
 
 
-const Lang = imports.lang;
 const St = imports.gi.St;
 const Clutter = imports.gi.Clutter;
 const GLib = imports.gi.GLib;
+const GObject = imports.gi.GObject;
 
 const Me = imports.misc.extensionUtils.getCurrentExtension();
 const Stuff = Me.imports.stuff;
@@ -33,19 +33,16 @@ const Stuff = Me.imports.stuff;
 /**
  * Custom Label widget that displays category totals.
  */
-var CategoryTotalsWidget = new Lang.Class({
-    Name: 'CategoryTotals',
-    Extends: St.Label,
-
-    _init: function() {
-        this.parent({style_class: 'summary-label'});
-
-    },
+var CategoryTotalsWidget = GObject.registerClass(
+class CategoryTotals extends St.Label {
+    _init() {
+        super._init({style_class: 'summary-label'});
+    }
 
     /**
      * Recompute values and replace old string with new one based on passed facts.
      */
-    refresh: function(facts) {
+    refresh(facts) {
         /**
          * Construct a string representing category totals.
          */
@@ -67,5 +64,5 @@ var CategoryTotalsWidget = new Lang.Class({
         }
 
         this.set_text(getString(facts));
-    },
+    }
 });

--- a/extension/widgets/factsBox.js
+++ b/extension/widgets/factsBox.js
@@ -21,12 +21,12 @@ Copyright (c) 2016 - 2018 Eric Goller / projecthamster <elbenfreund@projecthamst
 */
 
 
-const Lang = imports.lang;
 const St = imports.gi.St;
 const PopupMenu = imports.ui.popupMenu;
 const Clutter = imports.gi.Clutter;
 const Mainloop = imports.mainloop;
 const GLib = imports.gi.GLib;
+const GObject = imports.gi.GObject;
 
 const Gettext = imports.gettext.domain('hamster-shell-extension');
 const _ = Gettext.gettext;
@@ -43,11 +43,10 @@ const TodaysFactsWidget = Me.imports.widgets.todaysFactsWidget.TodaysFactsWidget
  * well as todays facts.
  * @class
  */
-var FactsBox = new Lang.Class({
-    Name: 'FactsBox',
-    Extends: PopupMenu.PopupBaseMenuItem,
-    _init: function(controller, panelWidget) {
-        this.parent({reactive: false});
+var FactsBox =
+class FactsBox extends PopupMenu.PopupBaseMenuItem {
+    constructor(controller, panelWidget) {
+        super({reactive: false});
 
         this._controller = controller;
 
@@ -62,7 +61,7 @@ var FactsBox = new Lang.Class({
         main_box.add(_ongoingFactLabel);
 
         this.ongoingFactEntry = new OngoingFactEntry(this._controller);
-        //this.ongoingFactEntry.clutter_text.connect('key-release-event', Lang.bind(this, this._onKeyReleaseEvent));
+        //this.ongoingFactEntry.clutter_text.connect('key-release-event', this._onKeyReleaseEvent.bind(this));
         main_box.add(this.ongoingFactEntry);
 
         let fact_list_label = new St.Label({style_class: 'hamster-box-label'});
@@ -79,32 +78,32 @@ var FactsBox = new Lang.Class({
         // Setup category summery
         this.summaryLabel = new CategoryTotalsWidget();
         main_box.add(this.summaryLabel);
-    },
+    }
 
     // [FIXME]
     // The best solution would be to listen for a 'FactsChanged' Signal that carries the new
     // facts as payload and just refresh with this. But for now we stick with this
     // simpler version.
-    refresh: function(facts, ongoingFact) {
+    refresh(facts, ongoingFact) {
         this.todaysFactsWidget.refresh(facts, ongoingFact);
         this.summaryLabel.refresh(facts);
 
-    },
+    }
 
     /**
      * Focus the fact entry and make sure todaysFactsWidget are scrolled to the bottom.
      */
-    focus: function() {
-        Mainloop.timeout_add(20, Lang.bind(this, function() {
+    focus() {
+        Mainloop.timeout_add(20, () => {
             this._scrollAdjustment.value = this._scrollAdjustment.upper;
             global.stage.set_key_focus(this.ongoingFactEntry);
-        }));
-    },
+        });
+    }
 
     /**
      * Remove any existing focus.
      */
-    unfocus: function() {
+    unfocus() {
         global.stage.set_key_focus(null);
-    },
-});
+    }
+};

--- a/extension/widgets/ongoingFactEntry.js
+++ b/extension/widgets/ongoingFactEntry.js
@@ -21,14 +21,12 @@ Copyright (c) 2016 - 2018 Eric Goller / projecthamster <elbenfreund@projecthamst
 */
 
 
-const Lang = imports.lang;
+const GObject = imports.gi.GObject;
 const St = imports.gi.St;
 const Clutter = imports.gi.Clutter;
 
 const Gettext = imports.gettext.domain('hamster-shell-extension');
 const _ = Gettext.gettext;
-
-const Me = imports.misc.extensionUtils.getCurrentExtension();
 
 
 /**
@@ -39,12 +37,10 @@ const Me = imports.misc.extensionUtils.getCurrentExtension();
  *
  *
  */
-var OngoingFactEntry = new Lang.Class({
-    Name: 'OngoingFactEntry',
-    Extends: St.Entry,
-
-    _init: function(controller) {
-        this.parent({
+var OngoingFactEntry = GObject.registerClass(
+class OngoingFactEntry extends St.Entry {
+    _init(controller) {
+        super._init({
             name: 'searchEntry',
             can_focus: true,
             track_hover: true,
@@ -57,9 +53,9 @@ var OngoingFactEntry = new Lang.Class({
         // Seems to be populate by GetActivities.
         this._autocompleteActivities = [];
         this._runningActivitiesQuery = null;
-        this.clutter_text.connect('activate', Lang.bind(this, this._onEntryActivated));
-        this.clutter_text.connect('key-release-event', Lang.bind(this, this._onKeyReleaseEvent));
-    },
+        this.clutter_text.connect('activate', this._onEntryActivated.bind(this));
+        this.clutter_text.connect('key-release-event', this._onKeyReleaseEvent.bind(this));
+    }
 
     /**
      * Callback for when ``ongoingFactEntry`` gets activated.
@@ -70,13 +66,13 @@ var OngoingFactEntry = new Lang.Class({
      *
      * @callback FactsBox~_onEntryActivated
      */
-    _onEntryActivated: function() {
+    _onEntryActivated() {
         let text = this.get_text();
-        this._controller.apiProxy.AddFactRemote(text, 0, 0, false, Lang.bind(this, function(response, error) {
+        this._controller.apiProxy.AddFactRemote(text, 0, 0, false, (response, error) => {
             // not interested in the new id - this shuts up the warning
-        }));
+        });
         this.set_text('');
-    },
+    }
 
     /**
      * Callback triggered after key release.
@@ -85,7 +81,7 @@ var OngoingFactEntry = new Lang.Class({
      *
      * @callback FactsBox~_onKeyReleaseEvent
      */
-    _onKeyReleaseEvent: function(textItem, evt) {
+    _onKeyReleaseEvent(textItem, evt) {
         /**
          * Check if the passed key is on our list of keys to be ignored.
          */
@@ -185,5 +181,5 @@ var OngoingFactEntry = new Lang.Class({
                 this._prevText = completion.toLowerCase();
             }
         }
-    },
+    }
 });

--- a/extension/widgets/panelWidget.js
+++ b/extension/widgets/panelWidget.js
@@ -21,8 +21,8 @@ Copyright (c) 2016 - 2018 Eric Goller / projecthamster <elbenfreund@projecthamst
 */
 
 
-const Lang = imports.lang;
 const Gio = imports.gi.Gio;
+const GObject = imports.gi.GObject;
 const Clutter = imports.gi.Clutter;
 const PanelMenu = imports.ui.panelMenu;
 const St = imports.gi.St;
@@ -55,14 +55,12 @@ const Stuff = Me.imports.stuff;
  *
  * @class
  */
-var PanelWidget = new Lang.Class({
-    Name: 'PanelWidget',
-    Extends: PanelMenu.Button,
-
-    _init: function(controller) {
+var PanelWidget = GObject.registerClass(
+class PanelWidget extends PanelMenu.Button {
+    _init(controller) {
         // [FIXME]
         // What is the parameter?
-        this.parent(0.0);
+        super._init(0.0);
 
         this._controller = controller;
         // [FIXME]
@@ -71,8 +69,8 @@ var PanelWidget = new Lang.Class({
         this._settings = controller.settings;
         this._windowsProxy = controller.windowsProxy;
 
-        controller.apiProxy.connectSignal('FactsChanged',      Lang.bind(this, this.refresh));
-        controller.apiProxy.connectSignal('TagsChanged',       Lang.bind(this, this.refresh));
+        controller.apiProxy.connectSignal('FactsChanged',      this.refresh.bind(this));
+        controller.apiProxy.connectSignal('TagsChanged',       this.refresh.bind(this));
 
 
         // Setup the main layout container for the part of the extension
@@ -104,43 +102,43 @@ var PanelWidget = new Lang.Class({
 
         // overview
         let overviewMenuItem = new PopupMenu.PopupMenuItem(_("Show Overview"));
-        overviewMenuItem.connect('activate', Lang.bind(this, this._onOpenOverview));
+        overviewMenuItem.connect('activate', this._onOpenOverview.bind(this));
         this.menu.addMenuItem(overviewMenuItem);
 
         // [FIXME]
         // This should only be shown if we have an 'ongoing fact'.
         // stop tracking
         let stopTrackinMenuItem = new PopupMenu.PopupMenuItem(_("Stop Tracking"));
-        stopTrackinMenuItem.connect('activate', Lang.bind(this, this._onStopTracking));
+        stopTrackinMenuItem.connect('activate', this._onStopTracking.bind(this));
         this.menu.addMenuItem(stopTrackinMenuItem);
 
         // add new task
         let addNewFactMenuItem = new PopupMenu.PopupMenuItem(_("Add Earlier Activity"));
-        addNewFactMenuItem.connect('activate', Lang.bind(this, this._onOpenAddFact));
+        addNewFactMenuItem.connect('activate', this._onOpenAddFact.bind(this));
         this.menu.addMenuItem(addNewFactMenuItem);
 
         // settings
         this.menu.addMenuItem(new PopupMenu.PopupSeparatorMenuItem());
         let SettingMenuItem = new PopupMenu.PopupMenuItem(_("Tracking Settings"));
-        SettingMenuItem.connect('activate', Lang.bind(this, this._onOpenSettings));
+        SettingMenuItem.connect('activate', this._onOpenSettings.bind(this));
         this.menu.addMenuItem(SettingMenuItem);
 
         // focus menu upon display
-        this.menu.connect('open-state-changed', Lang.bind(this,
-            function(menu, open) {
+        this.menu.connect('open-state-changed',
+            (menu, open) => {
                 if (open) {
                     this.factsBox.focus();
                 } else {
                     this.factsBox.unfocus();
                 }
             }
-        ));
+        );
 
         // refresh the widget every 60 secs
-        this.timeout = GLib.timeout_add_seconds(0, 60, Lang.bind(this, this.refresh));
-        this.connect('destroy', Lang.bind(this, this._disableRefreshTimer));
+        this.timeout = GLib.timeout_add_seconds(0, 60, this.refresh.bind(this));
+        this.connect('destroy', this._disableRefreshTimer.bind(this));
         this.refresh();
-    },
+    }
 
     /**
      * This is our main 'update/refresh' method.
@@ -152,13 +150,17 @@ var PanelWidget = new Lang.Class({
      * required facts etc and pass them to the relevant sub-widget's
      * refresh methods.
      */
-    refresh: function() {
+    refresh() {
     /**
      * We need to wrap our actual refresh code in this callback for now as
      * I am having major difficulties using a syncronous dbus method call to
      * fetch the array of 'todaysFacts'.
      */
-	function _refresh([response], err) {
+        // [FIXME]
+        // This should really be a synchronous call fetching the facts.
+        // Once this is done, the actual code from the callback should follow
+        // here.
+        this._controller.apiProxy.GetTodaysFactsRemote(([response], err) => {
         /**
          * Extract *ongoing fact* from our list of facts. Due to how *legacy
          * hamster* works this is the first element in the array returned my
@@ -189,29 +191,24 @@ var PanelWidget = new Lang.Class({
 
 		this.updatePanelDisplay(ongoingFact);
 		this.factsBox.refresh(facts, ongoingFact);
-	}
+	});
 
-    // [FIXME]
-    // This should really be a synchronous call fetching the facts.
-    // Once this is done, the actual code from the callback should follow
-    // here.
-    this._controller.apiProxy.GetTodaysFactsRemote(Lang.bind(this, _refresh));
     return GLib.SOURCE_CONTINUE;
-    },
+    }
 
     /**
      * Open 'popup menu' containing the bulk of the extension widgets.
      */
-    show: function() {
+    show() {
         this.menu.open();
-    },
+    }
 
     /**
      * Close/Open the 'popup menu' depending on previous state.
      */
-    toggle: function() {
+    toggle() {
         this.menu.toggle();
-    },
+    }
 
 
     /**
@@ -220,7 +217,7 @@ var PanelWidget = new Lang.Class({
      * Depending on the 'display mode' set in the extensions settings this has
      * slightly different consequences.
      */
-    updatePanelDisplay: function(fact) {
+    updatePanelDisplay(fact) {
         /**
          * Return a text string representing the passed fact suitable for the panelLabel.
          *
@@ -262,7 +259,7 @@ var PanelWidget = new Lang.Class({
                 this.panelLabel.show();
                 break;
         }
-    },
+    }
 
     /**
      * Disable the refresh timer.
@@ -272,9 +269,9 @@ var PanelWidget = new Lang.Class({
      * This method is actually a callback triggered on the destroy
      * signal.
      */
-    _disableRefreshTimer: function() {
+    _disableRefreshTimer() {
         GLib.source_remove(this.timeout);
-    },
+    }
 
     /**
      * Callback to be triggered when an *ongoing fact* is stopped.
@@ -283,7 +280,7 @@ var PanelWidget = new Lang.Class({
      * This will get the current time and issue the ``StopTracking``
      * method call to the dbus interface.
      */
-    _onStopTracking: function() {
+    _onStopTracking() {
         let now = new Date();
         let epochSeconds = Date.UTC(now.getFullYear(),
                                     now.getMonth(),
@@ -293,25 +290,25 @@ var PanelWidget = new Lang.Class({
                                     now.getSeconds());
         epochSeconds = Math.floor(epochSeconds / 1000);
         this._controller.apiProxy.StopTrackingRemote(GLib.Variant.new('i', [epochSeconds]));
-    },
+    }
 
     /**
      * Callback that triggers opening of the *Overview*-Window.
      *
      * @callback panelWidget~_onOpenOverview
      */
-    _onOpenOverview: function() {
+    _onOpenOverview() {
         this._controller.windowsProxy.overviewSync();
-    },
+    }
 
     /**
      * Callback that triggers opening of the *Add Fact*-Window.
      *
      * @callback panelWidget~_onOpenAddFact
      */
-    _onOpenAddFact: function() {
+    _onOpenAddFact() {
         this._controller.windowsProxy.editSync(GLib.Variant.new('i', [0]));
-    },
+    }
 
     /**
      * Callback that triggers opening of the *Add Fact*-Window.
@@ -320,7 +317,7 @@ var PanelWidget = new Lang.Class({
      *
      * Note: This will open the GUI settings, not the extension settings!
      */
-    _onOpenSettings: function() {
+    _onOpenSettings() {
         this._controller.windowsProxy.preferencesSync();
-    },
+    }
 });

--- a/extension/widgets/todaysFactsWidget.js
+++ b/extension/widgets/todaysFactsWidget.js
@@ -21,10 +21,10 @@ Copyright (c) 2016 - 2018 Eric Goller / projecthamster <elbenfreund@projecthamst
 */
 
 
-const Lang = imports.lang;
 const St = imports.gi.St;
 const Clutter = imports.gi.Clutter;
 const GLib = imports.gi.GLib;
+const GObject = imports.gi.GObject;
 
 const Me = imports.misc.extensionUtils.getCurrentExtension();
 const Stuff = Me.imports.stuff;
@@ -33,12 +33,10 @@ const Stuff = Me.imports.stuff;
 /**
  * A widget that lists all facts for *today*.
  */
-var TodaysFactsWidget = new Lang.Class({
-    Name: 'TodaysFactsWidget',
-    Extends: St.ScrollView,
-
-    _init: function(controller, panelWidget) {
-        this.parent({style_class: 'hamster-scrollbox'});
+var TodaysFactsWidget = GObject.registerClass(
+class TodaysFactsWidget extends St.ScrollView {
+    _init(controller, panelWidget) {
+        super._init({style_class: 'hamster-scrollbox'});
         this._controller = controller;
         this._panelWidget = panelWidget;
 
@@ -53,12 +51,12 @@ var TodaysFactsWidget = new Lang.Class({
         this.factsBox.add(this.facts_widget);
         this.add_actor(this.factsBox);
 
-    },
+    }
 
     /**
      * Populate the widget with rows representing the passed facts.
      */
-    populateFactsWidget: function(facts, ongoingFact) {
+    populateFactsWidget(facts, ongoingFact) {
 
         /**
          * Construct an individual row within the widget - representing a single fact.
@@ -113,9 +111,9 @@ var TodaysFactsWidget = new Lang.Class({
                     factStr += " #" + fact.tags.join(", #");
                 }
 
-                controller.apiProxy.AddFactRemote(factStr, 0, 0, false, Lang.bind(this, function(response, err) {
+                controller.apiProxy.AddFactRemote(factStr, 0, 0, false, (response, err) => {
                     // not interested in the new id - this shuts up the warning
-                }));
+                });
                 menu.close();
             }
 
@@ -147,7 +145,7 @@ var TodaysFactsWidget = new Lang.Class({
             editButton.set_child(editIcon);
             // [FIXME]
             // Wouldn't it be cleaner to pass the fact as data payload to the callback binding?
-            editButton.connect('clicked', Lang.bind(this, onOpenEditDialog));
+            editButton.connect('clicked', onOpenEditDialog.bind(this));
 
             // Construct a 'start previous fact's activity as new' button.
             // This is only done if the *ongoing fact* activity is actually
@@ -159,7 +157,7 @@ var TodaysFactsWidget = new Lang.Class({
                 continueButton = new St.Button({style_class: 'clickable cell-button'});
                 continueButton.set_child(continueIcon);
                 continueButton.fact = fact;
-                continueButton.connect('clicked', Lang.bind(this, onContinueButton));
+                continueButton.connect('clicked', onContinueButton.bind(this));
             }
 
             //The order of the array will be the order in which they will be added to the row.
@@ -181,13 +179,13 @@ var TodaysFactsWidget = new Lang.Class({
             }
             rowCount += 1;
         }
-    },
+    }
 
     /**
      * Clear the widget and populate it anew.
      */
-    refresh: function(facts, ongoingFact) {
+    refresh(facts, ongoingFact) {
         this.facts_widget.remove_all_children();
         this.populateFactsWidget(facts, ongoingFact);
-    },
+    }
 });


### PR DESCRIPTION
This commit ports class declarations to those of ES6[0], drops the
convenience module[1] and updates function context binding[2],
adopting the arrow notation in places.

[0] - https://gitlab.gnome.org/GNOME/gnome-shell/merge_requests/361
[1] - https://gitlab.gnome.org/GNOME/gnome-shell-extensions/commit/bab4be1a597226a5fe8a29dcf3848be47e16a5e5
[2] - https://gitlab.gnome.org/GNOME/gnome-shell-extensions/commit/ba27cc4a64daf7f62174653362741de30c2f5b86

Fixes https://github.com/projecthamster/hamster-shell-extension/issues/307