### PR TITLE
Gnome 3.32 support - alternative pull request

### DIFF
--- a/.jshint.cfg
+++ b/.jshint.cfg
@@ -1,3 +1,4 @@
 {
-  "moz": true
+  "moz": true,
+  "esversion": 6
 }

--- a/Makefile
+++ b/Makefile
@@ -55,10 +55,7 @@ clean-test-docs:
 $(BUILDDIR):
 	mkdir -p $@
 
-$(BUILDDIR)/convenience.js:	$(BUILDDIR)
-	wget https://gitlab.gnome.org/GNOME/gnome-shell-extensions/raw/gnome-3-30/lib/convenience.js -O $@
-
-collect:	$(BUILDDIR)/convenience.js
+collect:
 	cp -R extension/* $(BUILDDIR)
 	cp -R data/* $(BUILDDIR)
 

--- a/README.rst
+++ b/README.rst
@@ -30,10 +30,11 @@ hamster`` which should bring up ``hamster-service`` and
 ``hamster-windows-service``.
 
 Install For Production
-~~~~~~~~~~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~~~~~~~~
 The extension is available on `the central extension repository <https://extensions.gnome.org/extension/425/project-hamster-extension>`_.
 
-Current compatible Gnome shell version: 3.30
+Current compatible Gnome shell version: 3.32. *This version is not compatible
+with Gnome shell 3.30 and earlier.*
 For previous shell versions check `releases <https://github.com/projecthamster/hamster-shell-extension/tags>`_.
 
 Creating a development environment

--- a/data/metadata.json
+++ b/data/metadata.json
@@ -10,17 +10,7 @@
     "gettext-domain": "hamster-shell-extension",
     "settings-schema": "org.gnome.shell.extensions.project-hamster",
     "shell-version": [
-        "3.10",
-        "3.12",
-        "3.14",
-        "3.16",
-        "3.18",
-        "3.20",
-        "3.22",
-        "3.24",
-        "3.26",
-        "3.28",
-        "3.30"
+        "3.32"
     ],
     "url": "https://github.com/projecthamster/hamster-shell-extension.git",
     "uuid": "contact@projecthamster.org"

--- a/docs/styleguide.rst
+++ b/docs/styleguide.rst
@@ -31,7 +31,7 @@ Code-style
 
 Documentation
 ---------------
-- We use `JSDoc syntax and blog tags <http://usejsdoc.org>`_ to document all
+- We use JSDoc syntax and blog tags to document all
   our code.
 - Headings should capitalise each word.
 - Please use ``-`` for unordered lists and ``#.`` for ordered lists unless you

--- a/extension/extension.js
+++ b/extension/extension.js
@@ -22,7 +22,6 @@ Copyright (c) 2016 - 2018 Eric Goller / projecthamster <elbenfreund@projecthamst
 
 
 const GLib = imports.gi.GLib;
-const Lang = imports.lang;
 const Shell = imports.gi.Shell;
 const Meta = imports.gi.Meta;
 const Main = imports.ui.main;
@@ -93,19 +92,20 @@ let WindowsProxy = Gio.DBusProxy.makeProxyWrapper(WindowsProxyIface);
  *
  * @class
  */
-function Controller(extensionMeta) {
+class Controller {
+    constructor(extensionMeta) {
     let dateMenu = Main.panel.statusArea.dateMenu;
 
-    return {
-        extensionMeta: extensionMeta,
-        panelWidget: null,
-        settings: null,
-        placement: 0,
-        apiProxy: null,
-        windowsProxy: null,
+        this.extensionMeta = extensionMeta;
+        this.panelWidget = null;
+        this.settings = null;
+        this.placement = 0;
+        this.apiProxy = null;
+        this.windowsProxy = null;
         // ``shouldEnable`` indicates if the 'magic' enable function has been called or not.
         // for details please see: https://github.com/projecthamster/hamster-shell-extension/pull/239
-        shouldEnable: false,
+        this.shouldEnable = false;
+    }
 
         /**
          * 'Magic' method, called upon extension launch.
@@ -117,7 +117,7 @@ function Controller(extensionMeta) {
          *  We only set up our dbus proxies here. In order to be able to do so asynchronously all
          *  the actual startup code is refered to ``deferred_enable``.
          */
-        enable: function() {
+	enable() {
             this.shouldEnable = true;
             new ApiProxy(Gio.DBus.session, 'org.gnome.Hamster', '/org/gnome/Hamster',
                 function(proxy) {
@@ -130,9 +130,9 @@ function Controller(extensionMeta) {
                     this.windowsProxy = proxy;
                     this.deferred_enable();
                 }.bind(this));
-        },
+        }
 
-        deferred_enable: function() {
+        deferred_enable() {
             // Make sure ``enable`` is 'finished' and ``disable`` has not been
             // called in between.
             if (!this.shouldEnable || !this.apiProxy || !this.windowsProxy)
@@ -183,9 +183,9 @@ function Controller(extensionMeta) {
                 Shell.KeyBindingMode ? Shell.KeyBindingMode.ALL : Shell.ActionMode.ALL,
 				  this.panelWidget.toggle.bind(this.panelWidget)
             );
-        },
+        }
 
-        disable: function() {
+        disable() {
             this.shouldEnable = false;
             Main.wm.removeKeybinding("show-hamster-dropdown");
 
@@ -196,37 +196,29 @@ function Controller(extensionMeta) {
             this.panelWidget = null;
             this.apiProxy = null;
             this.windowsProxy = null;
-        },
+        }
 
         /**
          * Build a new cache of all activities present in the backend.
          */
-        refreshActivities: function() {
-            /**
-             * Return an Array of [Activity.name, Activity.category.name] Arrays.
-             *
-             */
-            function getActivities(controller) {
-                if (controller.runningActivitiesQuery) {
-                    return(controller.activities);
+        refreshActivities() {
+                if (this.runningActivitiesQuery) {
+                    return(this.activities);
                 }
 
                 this.runningActivitiesQuery = true;
-                controller.apiProxy.GetActivitiesRemote("", function([response], err) {
-                  controller.runningActivitiesQuery = false;
-                  controller.activities = response;
-                  global.log('ACTIVITIES HAMSTER: ', controller.activities);
+                this.apiProxy.GetActivitiesRemote("", function([response], err) {
+                  this.runningActivitiesQuery = false;
+                  this.activities = response;
+                  global.log('ACTIVITIES HAMSTER: ', this.activities);
                 }.bind(this));
-            }
-
-            getActivities(this);
-        },
+        }
 
         /**
          * Place the actual extension wi
          * get in the right place according to settings.
          */
-        _placeWidget: function(placement, panelWidget) {
+        _placeWidget(placement, panelWidget) {
             if (placement == 1) {
                 // 'Replace calendar'
                 Main.panel.addToStatusArea("hamster", this.panelWidget, 0, "center");
@@ -246,9 +238,9 @@ function Controller(extensionMeta) {
                 // 'Default'
                 Main.panel.addToStatusArea("hamster", this.panelWidget, 0, "right");
             }
-        },
+        }
 
-        _removeWidget: function(placement) {
+        _removeWidget(placement) {
             if (placement == 1) {
                 // We replaced the calendar
                 Main.panel._rightBox.remove_actor(dateMenu.container);
@@ -267,8 +259,7 @@ function Controller(extensionMeta) {
             } else {
                 Main.panel._rightBox.remove_actor(this.panelWidget.container);
             }
-        },
-    };
+        }
 }
 
 

--- a/extension/extension.js
+++ b/extension/extension.js
@@ -94,7 +94,7 @@ let WindowsProxy = Gio.DBusProxy.makeProxyWrapper(WindowsProxyIface);
  */
 class Controller {
     constructor(extensionMeta) {
-    let dateMenu = Main.panel.statusArea.dateMenu;
+	let dateMenu = Main.panel.statusArea.dateMenu;
 
         this.extensionMeta = extensionMeta;
         this.panelWidget = null;
@@ -107,161 +107,161 @@ class Controller {
         this.shouldEnable = false;
     }
 
-        /**
-         * 'Magic' method, called upon extension launch.
-         *
-         * The gnome-shell-extension API grantees that there is always a ``disable`` call in
-         * between to ``enable`` calls.
-         *
-         * Note:
-         *  We only set up our dbus proxies here. In order to be able to do so asynchronously all
-         *  the actual startup code is refered to ``deferred_enable``.
-         */
-	enable() {
-            this.shouldEnable = true;
-            new ApiProxy(Gio.DBus.session, 'org.gnome.Hamster', '/org/gnome/Hamster',
-                function(proxy) {
-                    this.apiProxy = proxy;
-                    this.deferred_enable();
-                }.bind(this));
-            new WindowsProxy(Gio.DBus.session, "org.gnome.Hamster.WindowServer",
-                "/org/gnome/Hamster/WindowServer",
-                function(proxy) {
-                    this.windowsProxy = proxy;
-                    this.deferred_enable();
-                }.bind(this));
+    /**
+     * 'Magic' method, called upon extension launch.
+     *
+     * The gnome-shell-extension API grantees that there is always a ``disable`` call in
+     * between to ``enable`` calls.
+     *
+     * Note:
+     *  We only set up our dbus proxies here. In order to be able to do so asynchronously all
+     *  the actual startup code is refered to ``deferred_enable``.
+     */
+    enable() {
+        this.shouldEnable = true;
+        new ApiProxy(Gio.DBus.session, 'org.gnome.Hamster', '/org/gnome/Hamster',
+                     function(proxy) {
+			 this.apiProxy = proxy;
+			 this.deferred_enable();
+                     }.bind(this));
+        new WindowsProxy(Gio.DBus.session, "org.gnome.Hamster.WindowServer",
+			 "/org/gnome/Hamster/WindowServer",
+			 function(proxy) {
+			     this.windowsProxy = proxy;
+			     this.deferred_enable();
+			 }.bind(this));
+    }
+
+    deferred_enable() {
+        // Make sure ``enable`` is 'finished' and ``disable`` has not been
+        // called in between.
+        if (!this.shouldEnable || !this.apiProxy || !this.windowsProxy)
+            return;
+
+        this.settings = ExtensionUtils.getSettings();
+        this.panelWidget = new PanelWidget(this);
+        this.placement = this.settings.get_int("panel-placement");
+
+        this._placeWidget(this.placement, this.panelWidget);
+
+        // Callbacks that handle appearing/vanishing dbus services.
+        function apiProxy_appeared_callback() {
         }
 
-        deferred_enable() {
-            // Make sure ``enable`` is 'finished' and ``disable`` has not been
-            // called in between.
-            if (!this.shouldEnable || !this.apiProxy || !this.windowsProxy)
-                return;
+        function apiProxy_vanished_callback() {
+	    /* jshint validthis: true */
+            global.log(_("hamster-shell-extension: 'hamster-service' not running. Shutting down."));
+            Main.notify(_("hamster-shell-extension: 'hamster-service' not running. Shutting down."));
+            this.disable();
+        }
 
-            this.settings = ExtensionUtils.getSettings();
-            this.panelWidget = new PanelWidget(this);
-            this.placement = this.settings.get_int("panel-placement");
+        function windowsProxy_appeared_callback() {
+        }
 
-            this._placeWidget(this.placement, this.panelWidget);
+        function windowsProxy_vanished_callback() {
+	    /* jshint validthis: true */
+            global.log(_("hamster-shell-extension: 'hamster-windows-service' not running. Shutting down."));
+            Main.notify(_("hamster-shell-extension: 'hamster-windows-service' not running. Shutting down."));
+            this.disable();
+        }
 
-            // Callbacks that handle appearing/vanishing dbus services.
-            function apiProxy_appeared_callback() {
-            }
+        // Set-up watchers that watch for required dbus services.
+        let dbus_watcher = Gio.bus_watch_name(Gio.BusType.SESSION, 'org.gnome.Hamster',
+					      Gio.BusNameWatcherFlags.NONE, apiProxy_appeared_callback.bind(this),
+					      apiProxy_vanished_callback.bind(this));
 
-            function apiProxy_vanished_callback() {
-		/* jshint validthis: true */
-                global.log(_("hamster-shell-extension: 'hamster-service' not running. Shutting down."));
-                Main.notify(_("hamster-shell-extension: 'hamster-service' not running. Shutting down."));
-                this.disable();
-            }
+        let dbus_watcher_window = Gio.bus_watch_name(Gio.BusType.SESSION, 'org.gnome.Hamster.WindowServer',
+						     Gio.BusNameWatcherFlags.NONE, windowsProxy_appeared_callback.bind(this),
+						     windowsProxy_vanished_callback.bind(this));
 
-            function windowsProxy_appeared_callback() {
-            }
+        this.apiProxy.connectSignal('ActivitiesChanged', this.refreshActivities.bind(this));
+        this.refreshActivities();
 
-            function windowsProxy_vanished_callback() {
-		/* jshint validthis: true */
-                global.log(_("hamster-shell-extension: 'hamster-windows-service' not running. Shutting down."));
-                Main.notify(_("hamster-shell-extension: 'hamster-windows-service' not running. Shutting down."));
-                this.disable();
-            }
+        Main.panel.menuManager.addMenu(this.panelWidget.menu);
+        Main.wm.addKeybinding("show-hamster-dropdown",
+			      this.panelWidget._settings,
+			      Meta.KeyBindingFlags.NONE,
+			      // Since Gnome 3.16, Shell.KeyBindingMode is replaced by Shell.ActionMode
+			      Shell.KeyBindingMode ? Shell.KeyBindingMode.ALL : Shell.ActionMode.ALL,
+			      this.panelWidget.toggle.bind(this.panelWidget)
+			     );
+    }
 
-            // Set-up watchers that watch for required dbus services.
-            let dbus_watcher = Gio.bus_watch_name(Gio.BusType.SESSION, 'org.gnome.Hamster',
-                Gio.BusNameWatcherFlags.NONE, apiProxy_appeared_callback.bind(this),
-                apiProxy_vanished_callback.bind(this));
+    disable() {
+        this.shouldEnable = false;
+        Main.wm.removeKeybinding("show-hamster-dropdown");
 
-            let dbus_watcher_window = Gio.bus_watch_name(Gio.BusType.SESSION, 'org.gnome.Hamster.WindowServer',
-                Gio.BusNameWatcherFlags.NONE, windowsProxy_appeared_callback.bind(this),
-                windowsProxy_vanished_callback.bind(this));
+        global.log('Shutting down hamster-shell-extension.');
+        this._removeWidget(this.placement);
+        Main.panel.menuManager.removeMenu(this.panelWidget.menu);
+        this.panelWidget.destroy();
+        this.panelWidget = null;
+        this.apiProxy = null;
+        this.windowsProxy = null;
+    }
 
-            this.apiProxy.connectSignal('ActivitiesChanged', this.refreshActivities.bind(this));
-            this.refreshActivities();
+    /**
+     * Build a new cache of all activities present in the backend.
+     */
+    refreshActivities() {
+        if (this.runningActivitiesQuery) {
+            return(this.activities);
+        }
 
-            Main.panel.menuManager.addMenu(this.panelWidget.menu);
-            Main.wm.addKeybinding("show-hamster-dropdown",
-                this.panelWidget._settings,
-                Meta.KeyBindingFlags.NONE,
-                // Since Gnome 3.16, Shell.KeyBindingMode is replaced by Shell.ActionMode
-                Shell.KeyBindingMode ? Shell.KeyBindingMode.ALL : Shell.ActionMode.ALL,
-				  this.panelWidget.toggle.bind(this.panelWidget)
+        this.runningActivitiesQuery = true;
+        this.apiProxy.GetActivitiesRemote("", function([response], err) {
+            this.runningActivitiesQuery = false;
+            this.activities = response;
+            global.log('ACTIVITIES HAMSTER: ', this.activities);
+        }.bind(this));
+    }
+
+    /**
+     * Place the actual extension wi
+     * get in the right place according to settings.
+     */
+    _placeWidget(placement, panelWidget) {
+        if (placement == 1) {
+            // 'Replace calendar'
+            Main.panel.addToStatusArea("hamster", this.panelWidget, 0, "center");
+
+            Main.panel._centerBox.remove_actor(dateMenu.container);
+            Main.panel._addToPanelBox('dateMenu', dateMenu, -1, Main.panel._rightBox);
+        } else if (placement == 2) {
+            // 'Replace activities'
+            let activitiesMenu = Main.panel._leftBox.get_children()[0].get_children()[0].get_children()[0].get_children()[0];
+            // If our widget replaces the 'Activities' menu in the panel,
+            // this property stores the original text so we can restore it
+            // on ``this.disable``.
+            this._activitiesText = activitiesMenu.get_text();
+            activitiesMenu.set_text('');
+            Main.panel.addToStatusArea("hamster", this.panelWidget, 1, "left");
+        } else {
+            // 'Default'
+            Main.panel.addToStatusArea("hamster", this.panelWidget, 0, "right");
+        }
+    }
+
+    _removeWidget(placement) {
+        if (placement == 1) {
+            // We replaced the calendar
+            Main.panel._rightBox.remove_actor(dateMenu.container);
+            Main.panel._addToPanelBox(
+                'dateMenu',
+                dateMenu,
+                Main.sessionMode.panel.center.indexOf('dateMenu'),
+                Main.panel._centerBox
             );
+            Main.panel._centerBox.remove_actor(this.panelWidget.container);
+        } else if (placement == 2) {
+            // We replaced the 'Activities' menu
+            let activitiesMenu = Main.panel._leftBox.get_children()[0].get_children()[0].get_children()[0].get_children()[0];
+            activitiesMenu.set_text(this._activitiesText);
+            Main.panel._leftBox.remove_actor(this.panelWidget.container);
+        } else {
+            Main.panel._rightBox.remove_actor(this.panelWidget.container);
         }
-
-        disable() {
-            this.shouldEnable = false;
-            Main.wm.removeKeybinding("show-hamster-dropdown");
-
-            global.log('Shutting down hamster-shell-extension.');
-            this._removeWidget(this.placement);
-            Main.panel.menuManager.removeMenu(this.panelWidget.menu);
-            this.panelWidget.destroy();
-            this.panelWidget = null;
-            this.apiProxy = null;
-            this.windowsProxy = null;
-        }
-
-        /**
-         * Build a new cache of all activities present in the backend.
-         */
-        refreshActivities() {
-                if (this.runningActivitiesQuery) {
-                    return(this.activities);
-                }
-
-                this.runningActivitiesQuery = true;
-                this.apiProxy.GetActivitiesRemote("", function([response], err) {
-                  this.runningActivitiesQuery = false;
-                  this.activities = response;
-                  global.log('ACTIVITIES HAMSTER: ', this.activities);
-                }.bind(this));
-        }
-
-        /**
-         * Place the actual extension wi
-         * get in the right place according to settings.
-         */
-        _placeWidget(placement, panelWidget) {
-            if (placement == 1) {
-                // 'Replace calendar'
-                Main.panel.addToStatusArea("hamster", this.panelWidget, 0, "center");
-
-                Main.panel._centerBox.remove_actor(dateMenu.container);
-                Main.panel._addToPanelBox('dateMenu', dateMenu, -1, Main.panel._rightBox);
-            } else if (placement == 2) {
-                // 'Replace activities'
-                let activitiesMenu = Main.panel._leftBox.get_children()[0].get_children()[0].get_children()[0].get_children()[0];
-                // If our widget replaces the 'Activities' menu in the panel,
-                // this property stores the original text so we can restore it
-                // on ``this.disable``.
-                this._activitiesText = activitiesMenu.get_text();
-                activitiesMenu.set_text('');
-                Main.panel.addToStatusArea("hamster", this.panelWidget, 1, "left");
-            } else {
-                // 'Default'
-                Main.panel.addToStatusArea("hamster", this.panelWidget, 0, "right");
-            }
-        }
-
-        _removeWidget(placement) {
-            if (placement == 1) {
-                // We replaced the calendar
-                Main.panel._rightBox.remove_actor(dateMenu.container);
-                Main.panel._addToPanelBox(
-                    'dateMenu',
-                    dateMenu,
-                    Main.sessionMode.panel.center.indexOf('dateMenu'),
-                    Main.panel._centerBox
-                );
-                Main.panel._centerBox.remove_actor(this.panelWidget.container);
-            } else if (placement == 2) {
-                // We replaced the 'Activities' menu
-                let activitiesMenu = Main.panel._leftBox.get_children()[0].get_children()[0].get_children()[0].get_children()[0];
-                activitiesMenu.set_text(this._activitiesText);
-                Main.panel._leftBox.remove_actor(this.panelWidget.container);
-            } else {
-                Main.panel._rightBox.remove_actor(this.panelWidget.container);
-            }
-        }
+    }
 }
 
 

--- a/extension/extension.js
+++ b/extension/extension.js
@@ -33,7 +33,6 @@ const _ = Gettext.gettext;
 
 const ExtensionUtils = imports.misc.extensionUtils;
 const Me = ExtensionUtils.getCurrentExtension();
-const Convenience = Me.imports.convenience;
 const PanelWidget = Me.imports.widgets.panelWidget.PanelWidget;
 
 // dbus-send --session --type=method_call --print-reply --dest=org.gnome.Hamster /org/gnome/Hamster org.freedesktop.DBus.Introspectable.Introspect
@@ -139,7 +138,7 @@ function Controller(extensionMeta) {
             if (!this.shouldEnable || !this.apiProxy || !this.windowsProxy)
                 return;
 
-            this.settings = Convenience.getSettings();
+            this.settings = ExtensionUtils.getSettings();
             this.panelWidget = new PanelWidget(this);
             this.placement = this.settings.get_int("panel-placement");
 
@@ -274,6 +273,6 @@ function Controller(extensionMeta) {
 
 
 function init(extensionMeta) {
-    Convenience.initTranslations();
+    ExtensionUtils.initTranslations();
     return new Controller(extensionMeta);
 }

--- a/extension/extension.js
+++ b/extension/extension.js
@@ -149,6 +149,7 @@ class Controller {
             }
 
             function apiProxy_vanished_callback() {
+		/* jshint validthis: true */
                 global.log(_("hamster-shell-extension: 'hamster-service' not running. Shutting down."));
                 Main.notify(_("hamster-shell-extension: 'hamster-service' not running. Shutting down."));
                 this.disable();
@@ -158,6 +159,7 @@ class Controller {
             }
 
             function windowsProxy_vanished_callback() {
+		/* jshint validthis: true */
                 global.log(_("hamster-shell-extension: 'hamster-windows-service' not running. Shutting down."));
                 Main.notify(_("hamster-shell-extension: 'hamster-windows-service' not running. Shutting down."));
                 this.disable();

--- a/extension/extension.js
+++ b/extension/extension.js
@@ -212,7 +212,7 @@ class Controller {
         this.apiProxy.GetActivitiesRemote("", function([response], err) {
             this.runningActivitiesQuery = false;
             this.activities = response;
-            global.log('ACTIVITIES HAMSTER: ', this.activities);
+            // global.log('ACTIVITIES HAMSTER: ', this.activities);
         }.bind(this));
     }
 

--- a/extension/extension.js
+++ b/extension/extension.js
@@ -120,16 +120,16 @@ function Controller(extensionMeta) {
         enable: function() {
             this.shouldEnable = true;
             new ApiProxy(Gio.DBus.session, 'org.gnome.Hamster', '/org/gnome/Hamster',
-                Lang.bind(this, function(proxy) {
+                function(proxy) {
                     this.apiProxy = proxy;
                     this.deferred_enable();
-                }));
+                }.bind(this));
             new WindowsProxy(Gio.DBus.session, "org.gnome.Hamster.WindowServer",
                 "/org/gnome/Hamster/WindowServer",
-                Lang.bind(this, function(proxy) {
+                function(proxy) {
                     this.windowsProxy = proxy;
                     this.deferred_enable();
-                }));
+                }.bind(this));
         },
 
         deferred_enable: function() {
@@ -172,7 +172,7 @@ function Controller(extensionMeta) {
                 Gio.BusNameWatcherFlags.NONE, windowsProxy_appeared_callback.bind(this),
                 windowsProxy_vanished_callback.bind(this));
 
-            this.apiProxy.connectSignal('ActivitiesChanged', Lang.bind(this, this.refreshActivities));
+            this.apiProxy.connectSignal('ActivitiesChanged', this.refreshActivities.bind(this));
             this.refreshActivities();
 
             Main.panel.menuManager.addMenu(this.panelWidget.menu);
@@ -181,7 +181,7 @@ function Controller(extensionMeta) {
                 Meta.KeyBindingFlags.NONE,
                 // Since Gnome 3.16, Shell.KeyBindingMode is replaced by Shell.ActionMode
                 Shell.KeyBindingMode ? Shell.KeyBindingMode.ALL : Shell.ActionMode.ALL,
-                Lang.bind(this.panelWidget, this.panelWidget.toggle)
+				  this.panelWidget.toggle.bind(this.panelWidget)
             );
         },
 
@@ -212,11 +212,11 @@ function Controller(extensionMeta) {
                 }
 
                 this.runningActivitiesQuery = true;
-                controller.apiProxy.GetActivitiesRemote("", Lang.bind(this, function([response], err) {
+                controller.apiProxy.GetActivitiesRemote("", function([response], err) {
                   controller.runningActivitiesQuery = false;
                   controller.activities = response;
                   global.log('ACTIVITIES HAMSTER: ', controller.activities);
-                }));
+                }.bind(this));
             }
 
             getActivities(this);

--- a/extension/prefs.js
+++ b/extension/prefs.js
@@ -30,7 +30,6 @@ const Lang = imports.lang;
 
 const ExtensionUtils = imports.misc.extensionUtils;
 const Me = ExtensionUtils.getCurrentExtension();
-const Convenience = Me.imports.convenience;
 
 const HamsterSettingsWidget = new GObject.Class({
     Name: 'ProjectHamster.Prefs.HamsterSettingsWidget',
@@ -41,7 +40,7 @@ const HamsterSettingsWidget = new GObject.Class({
         this.parent(params);
         this.margin = 10;
 
-        this._settings = Convenience.getSettings();
+        this._settings = ExtensionUtils.getSettings();
 
         let vbox, label;
 

--- a/extension/prefs.js
+++ b/extension/prefs.js
@@ -31,13 +31,13 @@ const Lang = imports.lang;
 const ExtensionUtils = imports.misc.extensionUtils;
 const Me = ExtensionUtils.getCurrentExtension();
 
-const HamsterSettingsWidget = new GObject.Class({
-    Name: 'ProjectHamster.Prefs.HamsterSettingsWidget',
-    GTypeName: 'HamsterSettingsWidget',
-    Extends: Gtk.VBox,
+const HamsterSettingsWidget = GObject.registerClass(
+class HamsterSettingsWidget extends Gtk.VBox {
+    _init(params) {
+        super._init(params);
 
-    _init : function(params) {
-        this.parent(params);
+        this.name = 'ProjectHamster.Prefs.HamsterSettingsWidget';
+
         this.margin = 10;
 
         this._settings = ExtensionUtils.getSettings();
@@ -114,9 +114,9 @@ const HamsterSettingsWidget = new GObject.Class({
         let version_text = ExtensionUtils.getCurrentExtension().metadata.version;
         let version_label_text = "You are running hamster-shell-extension version " + version_text;
         vbox.add(new Gtk.Label({label: version_label_text, margin_top: 10}));
-    },
+    }
 
-    _onPlacementChange: function(widget) {
+    _onPlacementChange(widget) {
         let [success, iter] = widget.get_active_iter();
         if (!success)
             return;
@@ -127,9 +127,9 @@ const HamsterSettingsWidget = new GObject.Class({
             return;
 
         this._settings.set_int("panel-placement", newPlacement);
-    },
+    }
 
-    _onAppearanceChange: function(widget) {
+    _onAppearanceChange(widget) {
         let [success, iter] = widget.get_active_iter();
         if (!success)
             return;
@@ -140,9 +140,9 @@ const HamsterSettingsWidget = new GObject.Class({
             return;
 
         this._settings.set_int("panel-appearance", newAppearance);
-    },
+    }
 
-    _onHotkeyChange: function(widget, bananas) {
+    _onHotkeyChange(widget, bananas) {
         //global.log(widget, bananas);
         let hotkey = widget.get_text();
         let [key, mods] = Gtk.accelerator_parse(hotkey);

--- a/extension/prefs.js
+++ b/extension/prefs.js
@@ -25,7 +25,6 @@ const Gdk = imports.gi.Gdk;
 const Gio = imports.gi.Gio;
 const Gtk = imports.gi.Gtk;
 const GObject = imports.gi.GObject;
-const Lang = imports.lang;
 
 
 const ExtensionUtils = imports.misc.extensionUtils;
@@ -64,7 +63,7 @@ class HamsterSettingsWidget extends Gtk.VBox {
         let placementComboRenderer = new Gtk.CellRendererText();
         placementCombo.pack_start(placementComboRenderer, true);
         placementCombo.add_attribute(placementComboRenderer, 'text', 0);
-        placementCombo.connect('changed', Lang.bind(this, this._onPlacementChange));
+        placementCombo.connect('changed', this._onPlacementChange.bind(this));
         placementCombo.set_active(this._settings.get_int("panel-placement"));
 
         vbox.add(placementCombo);
@@ -89,7 +88,7 @@ class HamsterSettingsWidget extends Gtk.VBox {
         let appearanceComboRenderer = new Gtk.CellRendererText();
         appearanceCombo.pack_start(appearanceComboRenderer, true);
         appearanceCombo.add_attribute(appearanceComboRenderer, 'text', 0);
-        appearanceCombo.connect('changed', Lang.bind(this, this._onAppearanceChange));
+        appearanceCombo.connect('changed', this._onAppearanceChange.bind(this));
         appearanceCombo.set_active(this._settings.get_int("panel-appearance"));
 
         vbox.add(appearanceCombo);
@@ -106,7 +105,7 @@ class HamsterSettingsWidget extends Gtk.VBox {
                                    margin_top: 5,
                                    text: this._settings.get_strv("show-hamster-dropdown")[0]});
         vbox.add(entry);
-        entry.connect('changed', Lang.bind(this, this._onHotkeyChange));
+        entry.connect('changed', this._onHotkeyChange.bind(this));
 
         vbox.add(new Gtk.Label({label: "Reload gnome shell after updating prefs (alt+f2 > r)",
                                 margin_top: 70}));

--- a/extension/widgets/categoryTotalsWidget.js
+++ b/extension/widgets/categoryTotalsWidget.js
@@ -25,6 +25,7 @@ const Lang = imports.lang;
 const St = imports.gi.St;
 const Clutter = imports.gi.Clutter;
 const GLib = imports.gi.GLib;
+const GObject = imports.gi.GObject;
 
 const Me = imports.misc.extensionUtils.getCurrentExtension();
 const Stuff = Me.imports.stuff;
@@ -33,19 +34,16 @@ const Stuff = Me.imports.stuff;
 /**
  * Custom Label widget that displays category totals.
  */
-var CategoryTotalsWidget = new Lang.Class({
-    Name: 'CategoryTotals',
-    Extends: St.Label,
-
-    _init: function() {
-        this.parent({style_class: 'summary-label'});
-
-    },
+var CategoryTotalsWidget = GObject.registerClass(
+class CategoryTotals extends St.Label {
+    _init() {
+        super._init({style_class: 'summary-label'});
+    }
 
     /**
      * Recompute values and replace old string with new one based on passed facts.
      */
-    refresh: function(facts) {
+    refresh(facts) {
         /**
          * Construct a string representing category totals.
          */
@@ -67,5 +65,5 @@ var CategoryTotalsWidget = new Lang.Class({
         }
 
         this.set_text(getString(facts));
-    },
+    }
 });

--- a/extension/widgets/categoryTotalsWidget.js
+++ b/extension/widgets/categoryTotalsWidget.js
@@ -21,7 +21,6 @@ Copyright (c) 2016 - 2018 Eric Goller / projecthamster <elbenfreund@projecthamst
 */
 
 
-const Lang = imports.lang;
 const St = imports.gi.St;
 const Clutter = imports.gi.Clutter;
 const GLib = imports.gi.GLib;

--- a/extension/widgets/factsBox.js
+++ b/extension/widgets/factsBox.js
@@ -21,7 +21,6 @@ Copyright (c) 2016 - 2018 Eric Goller / projecthamster <elbenfreund@projecthamst
 */
 
 
-const Lang = imports.lang;
 const St = imports.gi.St;
 const PopupMenu = imports.ui.popupMenu;
 const Clutter = imports.gi.Clutter;
@@ -62,7 +61,7 @@ class FactsBox extends PopupMenu.PopupBaseMenuItem {
         main_box.add(_ongoingFactLabel);
 
         this.ongoingFactEntry = new OngoingFactEntry(this._controller);
-        //this.ongoingFactEntry.clutter_text.connect('key-release-event', Lang.bind(this, this._onKeyReleaseEvent));
+        //this.ongoingFactEntry.clutter_text.connect('key-release-event', this._onKeyReleaseEvent.bind(this));
         main_box.add(this.ongoingFactEntry);
 
         let fact_list_label = new St.Label({style_class: 'hamster-box-label'});
@@ -95,10 +94,10 @@ class FactsBox extends PopupMenu.PopupBaseMenuItem {
      * Focus the fact entry and make sure todaysFactsWidget are scrolled to the bottom.
      */
     focus() {
-        Mainloop.timeout_add(20, Lang.bind(this, function() {
+        Mainloop.timeout_add(20, function() {
             this._scrollAdjustment.value = this._scrollAdjustment.upper;
             global.stage.set_key_focus(this.ongoingFactEntry);
-        }));
+        }.bind(this));
     }
 
     /**

--- a/extension/widgets/factsBox.js
+++ b/extension/widgets/factsBox.js
@@ -27,6 +27,7 @@ const PopupMenu = imports.ui.popupMenu;
 const Clutter = imports.gi.Clutter;
 const Mainloop = imports.mainloop;
 const GLib = imports.gi.GLib;
+const GObject = imports.gi.GObject;
 
 const Gettext = imports.gettext.domain('hamster-shell-extension');
 const _ = Gettext.gettext;
@@ -43,11 +44,10 @@ const TodaysFactsWidget = Me.imports.widgets.todaysFactsWidget.TodaysFactsWidget
  * well as todays facts.
  * @class
  */
-var FactsBox = new Lang.Class({
-    Name: 'FactsBox',
-    Extends: PopupMenu.PopupBaseMenuItem,
-    _init: function(controller, panelWidget) {
-        this.parent({reactive: false});
+var FactsBox =
+class FactsBox extends PopupMenu.PopupBaseMenuItem {
+    constructor(controller, panelWidget) {
+        super({reactive: false});
 
         this._controller = controller;
 
@@ -79,32 +79,32 @@ var FactsBox = new Lang.Class({
         // Setup category summery
         this.summaryLabel = new CategoryTotalsWidget();
         main_box.add(this.summaryLabel);
-    },
+    }
 
     // [FIXME]
     // The best solution would be to listen for a 'FactsChanged' Signal that carries the new
     // facts as payload and just refresh with this. But for now we stick with this
     // simpler version.
-    refresh: function(facts, ongoingFact) {
+    refresh(facts, ongoingFact) {
         this.todaysFactsWidget.refresh(facts, ongoingFact);
         this.summaryLabel.refresh(facts);
 
-    },
+    }
 
     /**
      * Focus the fact entry and make sure todaysFactsWidget are scrolled to the bottom.
      */
-    focus: function() {
+    focus() {
         Mainloop.timeout_add(20, Lang.bind(this, function() {
             this._scrollAdjustment.value = this._scrollAdjustment.upper;
             global.stage.set_key_focus(this.ongoingFactEntry);
         }));
-    },
+    }
 
     /**
      * Remove any existing focus.
      */
-    unfocus: function() {
+    unfocus() {
         global.stage.set_key_focus(null);
-    },
-});
+    }
+};

--- a/extension/widgets/ongoingFactEntry.js
+++ b/extension/widgets/ongoingFactEntry.js
@@ -22,6 +22,7 @@ Copyright (c) 2016 - 2018 Eric Goller / projecthamster <elbenfreund@projecthamst
 
 
 const Lang = imports.lang;
+const GObject = imports.gi.GObject;
 const St = imports.gi.St;
 const Clutter = imports.gi.Clutter;
 
@@ -39,12 +40,10 @@ const Me = imports.misc.extensionUtils.getCurrentExtension();
  *
  *
  */
-var OngoingFactEntry = new Lang.Class({
-    Name: 'OngoingFactEntry',
-    Extends: St.Entry,
-
-    _init: function(controller) {
-        this.parent({
+var OngoingFactEntry = GObject.registerClass(
+class OngoingFactEntry extends St.Entry {
+    _init(controller) {
+        super._init({
             name: 'searchEntry',
             can_focus: true,
             track_hover: true,
@@ -59,7 +58,7 @@ var OngoingFactEntry = new Lang.Class({
         this._runningActivitiesQuery = null;
         this.clutter_text.connect('activate', Lang.bind(this, this._onEntryActivated));
         this.clutter_text.connect('key-release-event', Lang.bind(this, this._onKeyReleaseEvent));
-    },
+    }
 
     /**
      * Callback for when ``ongoingFactEntry`` gets activated.
@@ -70,13 +69,13 @@ var OngoingFactEntry = new Lang.Class({
      *
      * @callback FactsBox~_onEntryActivated
      */
-    _onEntryActivated: function() {
+    _onEntryActivated() {
         let text = this.get_text();
         this._controller.apiProxy.AddFactRemote(text, 0, 0, false, Lang.bind(this, function(response, error) {
             // not interested in the new id - this shuts up the warning
         }));
         this.set_text('');
-    },
+    }
 
     /**
      * Callback triggered after key release.
@@ -85,7 +84,7 @@ var OngoingFactEntry = new Lang.Class({
      *
      * @callback FactsBox~_onKeyReleaseEvent
      */
-    _onKeyReleaseEvent: function(textItem, evt) {
+    _onKeyReleaseEvent(textItem, evt) {
         /**
          * Check if the passed key is on our list of keys to be ignored.
          */
@@ -185,5 +184,5 @@ var OngoingFactEntry = new Lang.Class({
                 this._prevText = completion.toLowerCase();
             }
         }
-    },
+    }
 });

--- a/extension/widgets/ongoingFactEntry.js
+++ b/extension/widgets/ongoingFactEntry.js
@@ -21,7 +21,6 @@ Copyright (c) 2016 - 2018 Eric Goller / projecthamster <elbenfreund@projecthamst
 */
 
 
-const Lang = imports.lang;
 const GObject = imports.gi.GObject;
 const St = imports.gi.St;
 const Clutter = imports.gi.Clutter;
@@ -56,8 +55,8 @@ class OngoingFactEntry extends St.Entry {
         // Seems to be populate by GetActivities.
         this._autocompleteActivities = [];
         this._runningActivitiesQuery = null;
-        this.clutter_text.connect('activate', Lang.bind(this, this._onEntryActivated));
-        this.clutter_text.connect('key-release-event', Lang.bind(this, this._onKeyReleaseEvent));
+        this.clutter_text.connect('activate', this._onEntryActivated.bind(this));
+        this.clutter_text.connect('key-release-event', this._onKeyReleaseEvent.bind(this));
     }
 
     /**
@@ -71,9 +70,9 @@ class OngoingFactEntry extends St.Entry {
      */
     _onEntryActivated() {
         let text = this.get_text();
-        this._controller.apiProxy.AddFactRemote(text, 0, 0, false, Lang.bind(this, function(response, error) {
+        this._controller.apiProxy.AddFactRemote(text, 0, 0, false, function(response, error) {
             // not interested in the new id - this shuts up the warning
-        }));
+	}.bind(this));
         this.set_text('');
     }
 

--- a/extension/widgets/panelWidget.js
+++ b/extension/widgets/panelWidget.js
@@ -23,6 +23,7 @@ Copyright (c) 2016 - 2018 Eric Goller / projecthamster <elbenfreund@projecthamst
 
 const Lang = imports.lang;
 const Gio = imports.gi.Gio;
+const GObject = imports.gi.GObject;
 const Clutter = imports.gi.Clutter;
 const PanelMenu = imports.ui.panelMenu;
 const St = imports.gi.St;
@@ -55,14 +56,12 @@ const Stuff = Me.imports.stuff;
  *
  * @class
  */
-var PanelWidget = new Lang.Class({
-    Name: 'PanelWidget',
-    Extends: PanelMenu.Button,
-
-    _init: function(controller) {
+var PanelWidget = GObject.registerClass(
+class PanelWidget extends PanelMenu.Button {
+    _init(controller) {
         // [FIXME]
         // What is the parameter?
-        this.parent(0.0);
+        super._init(0.0);
 
         this._controller = controller;
         // [FIXME]
@@ -140,7 +139,7 @@ var PanelWidget = new Lang.Class({
         this.timeout = GLib.timeout_add_seconds(0, 60, Lang.bind(this, this.refresh));
         this.connect('destroy', Lang.bind(this, this._disableRefreshTimer));
         this.refresh();
-    },
+    }
 
     /**
      * This is our main 'update/refresh' method.
@@ -152,7 +151,7 @@ var PanelWidget = new Lang.Class({
      * required facts etc and pass them to the relevant sub-widget's
      * refresh methods.
      */
-    refresh: function() {
+    refresh() {
     /**
      * We need to wrap our actual refresh code in this callback for now as
      * I am having major difficulties using a syncronous dbus method call to
@@ -197,21 +196,21 @@ var PanelWidget = new Lang.Class({
     // here.
     this._controller.apiProxy.GetTodaysFactsRemote(Lang.bind(this, _refresh));
     return GLib.SOURCE_CONTINUE;
-    },
+    }
 
     /**
      * Open 'popup menu' containing the bulk of the extension widgets.
      */
-    show: function() {
+    show() {
         this.menu.open();
-    },
+    }
 
     /**
      * Close/Open the 'popup menu' depending on previous state.
      */
-    toggle: function() {
+    toggle() {
         this.menu.toggle();
-    },
+    }
 
 
     /**
@@ -220,7 +219,7 @@ var PanelWidget = new Lang.Class({
      * Depending on the 'display mode' set in the extensions settings this has
      * slightly different consequences.
      */
-    updatePanelDisplay: function(fact) {
+    updatePanelDisplay(fact) {
         /**
          * Return a text string representing the passed fact suitable for the panelLabel.
          *
@@ -262,7 +261,7 @@ var PanelWidget = new Lang.Class({
                 this.panelLabel.show();
                 break;
         }
-    },
+    }
 
     /**
      * Disable the refresh timer.
@@ -272,9 +271,9 @@ var PanelWidget = new Lang.Class({
      * This method is actually a callback triggered on the destroy
      * signal.
      */
-    _disableRefreshTimer: function() {
+    _disableRefreshTimer() {
         GLib.source_remove(this.timeout);
-    },
+    }
 
     /**
      * Callback to be triggered when an *ongoing fact* is stopped.
@@ -283,7 +282,7 @@ var PanelWidget = new Lang.Class({
      * This will get the current time and issue the ``StopTracking``
      * method call to the dbus interface.
      */
-    _onStopTracking: function() {
+    _onStopTracking() {
         let now = new Date();
         let epochSeconds = Date.UTC(now.getFullYear(),
                                     now.getMonth(),
@@ -293,25 +292,25 @@ var PanelWidget = new Lang.Class({
                                     now.getSeconds());
         epochSeconds = Math.floor(epochSeconds / 1000);
         this._controller.apiProxy.StopTrackingRemote(GLib.Variant.new('i', [epochSeconds]));
-    },
+    }
 
     /**
      * Callback that triggers opening of the *Overview*-Window.
      *
      * @callback panelWidget~_onOpenOverview
      */
-    _onOpenOverview: function() {
+    _onOpenOverview() {
         this._controller.windowsProxy.overviewSync();
-    },
+    }
 
     /**
      * Callback that triggers opening of the *Add Fact*-Window.
      *
      * @callback panelWidget~_onOpenAddFact
      */
-    _onOpenAddFact: function() {
+    _onOpenAddFact() {
         this._controller.windowsProxy.editSync(GLib.Variant.new('i', [0]));
-    },
+    }
 
     /**
      * Callback that triggers opening of the *Add Fact*-Window.
@@ -320,7 +319,7 @@ var PanelWidget = new Lang.Class({
      *
      * Note: This will open the GUI settings, not the extension settings!
      */
-    _onOpenSettings: function() {
+    _onOpenSettings() {
         this._controller.windowsProxy.preferencesSync();
-    },
+    }
 });

--- a/extension/widgets/panelWidget.js
+++ b/extension/widgets/panelWidget.js
@@ -165,6 +165,7 @@ class PanelWidget extends PanelMenu.Button {
          *
          * Returns ``null`` if there is no *ongoing fact*.
          */
+        /* jshint validthis: true */
 		function getOngoingFact(facts) {
 		    let result = null;
 		    if (facts.length) {

--- a/extension/widgets/panelWidget.js
+++ b/extension/widgets/panelWidget.js
@@ -21,7 +21,6 @@ Copyright (c) 2016 - 2018 Eric Goller / projecthamster <elbenfreund@projecthamst
 */
 
 
-const Lang = imports.lang;
 const Gio = imports.gi.Gio;
 const GObject = imports.gi.GObject;
 const Clutter = imports.gi.Clutter;
@@ -70,8 +69,8 @@ class PanelWidget extends PanelMenu.Button {
         this._settings = controller.settings;
         this._windowsProxy = controller.windowsProxy;
 
-        controller.apiProxy.connectSignal('FactsChanged',      Lang.bind(this, this.refresh));
-        controller.apiProxy.connectSignal('TagsChanged',       Lang.bind(this, this.refresh));
+        controller.apiProxy.connectSignal('FactsChanged',      this.refresh.bind(this));
+        controller.apiProxy.connectSignal('TagsChanged',       this.refresh.bind(this));
 
 
         // Setup the main layout container for the part of the extension
@@ -103,41 +102,41 @@ class PanelWidget extends PanelMenu.Button {
 
         // overview
         let overviewMenuItem = new PopupMenu.PopupMenuItem(_("Show Overview"));
-        overviewMenuItem.connect('activate', Lang.bind(this, this._onOpenOverview));
+        overviewMenuItem.connect('activate', this._onOpenOverview.bind(this));
         this.menu.addMenuItem(overviewMenuItem);
 
         // [FIXME]
         // This should only be shown if we have an 'ongoing fact'.
         // stop tracking
         let stopTrackinMenuItem = new PopupMenu.PopupMenuItem(_("Stop Tracking"));
-        stopTrackinMenuItem.connect('activate', Lang.bind(this, this._onStopTracking));
+        stopTrackinMenuItem.connect('activate', this._onStopTracking.bind(this));
         this.menu.addMenuItem(stopTrackinMenuItem);
 
         // add new task
         let addNewFactMenuItem = new PopupMenu.PopupMenuItem(_("Add Earlier Activity"));
-        addNewFactMenuItem.connect('activate', Lang.bind(this, this._onOpenAddFact));
+        addNewFactMenuItem.connect('activate', this._onOpenAddFact.bind(this));
         this.menu.addMenuItem(addNewFactMenuItem);
 
         // settings
         this.menu.addMenuItem(new PopupMenu.PopupSeparatorMenuItem());
         let SettingMenuItem = new PopupMenu.PopupMenuItem(_("Tracking Settings"));
-        SettingMenuItem.connect('activate', Lang.bind(this, this._onOpenSettings));
+        SettingMenuItem.connect('activate', this._onOpenSettings.bind(this));
         this.menu.addMenuItem(SettingMenuItem);
 
         // focus menu upon display
-        this.menu.connect('open-state-changed', Lang.bind(this,
+        this.menu.connect('open-state-changed',
             function(menu, open) {
                 if (open) {
                     this.factsBox.focus();
                 } else {
                     this.factsBox.unfocus();
                 }
-            }
-        ));
+            }.bind(this)
+        );
 
         // refresh the widget every 60 secs
-        this.timeout = GLib.timeout_add_seconds(0, 60, Lang.bind(this, this.refresh));
-        this.connect('destroy', Lang.bind(this, this._disableRefreshTimer));
+        this.timeout = GLib.timeout_add_seconds(0, 60, this.refresh.bind(this));
+        this.connect('destroy', this._disableRefreshTimer.bind(this));
         this.refresh();
     }
 
@@ -195,7 +194,7 @@ class PanelWidget extends PanelMenu.Button {
     // This should really be a synchronous call fetching the facts.
     // Once this is done, the actual code from the callback should follow
     // here.
-    this._controller.apiProxy.GetTodaysFactsRemote(Lang.bind(this, _refresh));
+    this._controller.apiProxy.GetTodaysFactsRemote(_refresh.bind(this));
     return GLib.SOURCE_CONTINUE;
     }
 

--- a/extension/widgets/todaysFactsWidget.js
+++ b/extension/widgets/todaysFactsWidget.js
@@ -66,6 +66,7 @@ class TodaysFactsWidget extends St.ScrollView {
             /**
              * Check if two facts have the same activity.
              */
+	    /* jshint validthis: true */
             function checkSameActivity(fact, otherFact) {
                 // Check if two facts have the same activity.
                 let result = true;
@@ -112,6 +113,7 @@ class TodaysFactsWidget extends St.ScrollView {
                     factStr += " #" + fact.tags.join(", #");
                 }
 
+		/* jshint validthis: true */
                 controller.apiProxy.AddFactRemote(factStr, 0, 0, false, Lang.bind(this, function(response, err) {
                     // not interested in the new id - this shuts up the warning
                 }));

--- a/extension/widgets/todaysFactsWidget.js
+++ b/extension/widgets/todaysFactsWidget.js
@@ -176,7 +176,7 @@ class TodaysFactsWidget extends St.ScrollView {
         let rowCount = 0;
         let layout = this.facts_widget.layout_manager;
         for (let fact of facts) {
-            let rowComponents = constructRow(fact, ongoingFact, this._controller, this._panelWidget.menu);
+            let rowComponents = Lang.bind(this, constructRow)(fact, ongoingFact, this._controller, this._panelWidget.menu);
             for (let component of rowComponents) {
                 layout.pack(component, rowComponents.indexOf(component), rowCount);
             }

--- a/extension/widgets/todaysFactsWidget.js
+++ b/extension/widgets/todaysFactsWidget.js
@@ -21,7 +21,6 @@ Copyright (c) 2016 - 2018 Eric Goller / projecthamster <elbenfreund@projecthamst
 */
 
 
-const Lang = imports.lang;
 const St = imports.gi.St;
 const Clutter = imports.gi.Clutter;
 const GLib = imports.gi.GLib;
@@ -114,9 +113,9 @@ class TodaysFactsWidget extends St.ScrollView {
                 }
 
 		/* jshint validthis: true */
-                controller.apiProxy.AddFactRemote(factStr, 0, 0, false, Lang.bind(this, function(response, err) {
+                controller.apiProxy.AddFactRemote(factStr, 0, 0, false, function(response, err) {
                     // not interested in the new id - this shuts up the warning
-                }));
+                }.bind(this));
                 menu.close();
             }
 
@@ -148,7 +147,7 @@ class TodaysFactsWidget extends St.ScrollView {
             editButton.set_child(editIcon);
             // [FIXME]
             // Wouldn't it be cleaner to pass the fact as data payload to the callback binding?
-            editButton.connect('clicked', Lang.bind(this, onOpenEditDialog));
+            editButton.connect('clicked', onOpenEditDialog.bind(this));
 
             // Construct a 'start previous fact's activity as new' button.
             // This is only done if the *ongoing fact* activity is actually
@@ -160,7 +159,7 @@ class TodaysFactsWidget extends St.ScrollView {
                 continueButton = new St.Button({style_class: 'clickable cell-button'});
                 continueButton.set_child(continueIcon);
                 continueButton.fact = fact;
-                continueButton.connect('clicked', Lang.bind(this, onContinueButton));
+                continueButton.connect('clicked', onContinueButton.bind(this));
             }
 
             //The order of the array will be the order in which they will be added to the row.
@@ -176,7 +175,7 @@ class TodaysFactsWidget extends St.ScrollView {
         let rowCount = 0;
         let layout = this.facts_widget.layout_manager;
         for (let fact of facts) {
-            let rowComponents = Lang.bind(this, constructRow)(fact, ongoingFact, this._controller, this._panelWidget.menu);
+            let rowComponents = constructRow.bind(this)(fact, ongoingFact, this._controller, this._panelWidget.menu);
             for (let component of rowComponents) {
                 layout.pack(component, rowComponents.indexOf(component), rowCount);
             }

--- a/extension/widgets/todaysFactsWidget.js
+++ b/extension/widgets/todaysFactsWidget.js
@@ -25,6 +25,7 @@ const Lang = imports.lang;
 const St = imports.gi.St;
 const Clutter = imports.gi.Clutter;
 const GLib = imports.gi.GLib;
+const GObject = imports.gi.GObject;
 
 const Me = imports.misc.extensionUtils.getCurrentExtension();
 const Stuff = Me.imports.stuff;
@@ -33,12 +34,10 @@ const Stuff = Me.imports.stuff;
 /**
  * A widget that lists all facts for *today*.
  */
-var TodaysFactsWidget = new Lang.Class({
-    Name: 'TodaysFactsWidget',
-    Extends: St.ScrollView,
-
-    _init: function(controller, panelWidget) {
-        this.parent({style_class: 'hamster-scrollbox'});
+var TodaysFactsWidget = GObject.registerClass(
+class TodaysFactsWidget extends St.ScrollView {
+    _init(controller, panelWidget) {
+        super._init({style_class: 'hamster-scrollbox'});
         this._controller = controller;
         this._panelWidget = panelWidget;
 
@@ -53,12 +52,12 @@ var TodaysFactsWidget = new Lang.Class({
         this.factsBox.add(this.facts_widget);
         this.add_actor(this.factsBox);
 
-    },
+    }
 
     /**
      * Populate the widget with rows representing the passed facts.
      */
-    populateFactsWidget: function(facts, ongoingFact) {
+    populateFactsWidget(facts, ongoingFact) {
 
         /**
          * Construct an individual row within the widget - representing a single fact.
@@ -181,13 +180,13 @@ var TodaysFactsWidget = new Lang.Class({
             }
             rowCount += 1;
         }
-    },
+    }
 
     /**
      * Clear the widget and populate it anew.
      */
-    refresh: function(facts, ongoingFact) {
+    refresh(facts, ongoingFact) {
         this.facts_widget.remove_all_children();
         this.populateFactsWidget(facts, ongoingFact);
-    },
+    }
 });


### PR DESCRIPTION
This PR aims to fix https://github.com/projecthamster/hamster-shell-extension/issues/307. It is almost equivalent to https://github.com/projecthamster/hamster-shell-extension/pull/308, and very heavily based on @ernestask's work there.

Differences are:

 * The branch is based on @hedayat's work for 3.30. As such, the first 5 commits up to 3e75499 are actually aimed at 3.30, and are partially reverted for 3.32 later in the series.
 * It's split into several commits for easier review
 * It does not introduce "Arrow" style function syntax (yet, this could be easily added later).
 * It adds a few comments for jshint to avoid problems in **make test-style**
 * It marks **only GNOME 3.32** as supported in this version (IMO necessary; other extensions do the same). 

If we want to support older GNOME versions in the future, we'll need to fork.

Note that the only parts that are necessary to make hamster-shell-extension work with GNOME 3.32 are 78bc2ff (plus the fix 76e961c) and 0621854.