### PR TITLE
Fix convenience.js URL

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -56,7 +56,7 @@ collect:
 	mkdir -p $(BUILDDIR)
 	cp -R extension/* $(BUILDDIR)
 	cp -R data/* $(BUILDDIR)
-	wget https://gitlab.gnome.org/GNOME/gnome-shell-extensions/raw/master/lib/convenience.js -O $(BUILDDIR)/convenience.js
+	wget https://gitlab.gnome.org/GNOME/gnome-shell-extensions/raw/gnome-3-30/lib/convenience.js -O $(BUILDDIR)/convenience.js
 
 compile: collect
 	glib-compile-schemas $(BUILDDIR)/schemas


### PR DESCRIPTION
Fixes #306 
Seems the 3.30 branch of gnome-shell-extensions has the file, 3.32 is when it was replaced and that was merged into master.