### PR TITLE
metadata.json: remove "version" field

### DIFF
--- a/data/metadata.json
+++ b/data/metadata.json
@@ -22,6 +22,5 @@
         "3.28"
     ],
     "url": "https://github.com/projecthamster/hamster-shell-extension.git",
-    "uuid": "contact@projecthamster.org",
-    "version": "0.10.0"
+    "uuid": "contact@projecthamster.org"
 }


### PR DESCRIPTION
Delete the "version" field from `metadata.json`. This is the result of discussions on #321, #323, #324, and [extensions-web #102](https://gitlab.gnome.org/Infrastructure/extensions-web/issues/102#note_740134),  [extensions-web #95](https://gitlab.gnome.org/Infrastructure/extensions-web/issues/95).

In order to not have to do this on every branch later, we should merge this PR before merging any "GNOME 3.3x support" PRs (#299, #312, #316, #323), even if it means that I need to rebase my PRs again.

@matthijskooijman, again, I couldn't invite you for review.