### PR TITLE
Stop tracking when the screensaver cuts in.

### DIFF
--- a/extension/widgets/panelWidget.js
+++ b/extension/widgets/panelWidget.js
@@ -285,15 +285,7 @@ class PanelWidget extends PanelMenu.Button {
      * method call to the dbus interface.
      */
     _onStopTracking() {
-        let now = new Date();
-        let epochSeconds = Date.UTC(now.getFullYear(),
-                                    now.getMonth(),
-                                    now.getDate(),
-                                    now.getHours(),
-                                    now.getMinutes(),
-                                    now.getSeconds());
-        epochSeconds = Math.floor(epochSeconds / 1000);
-        this._controller.apiProxy.StopTrackingRemote(GLib.Variant.new('i', [epochSeconds]));
+        this._controller.stopTracking();
     }
 
     /**


### PR DESCRIPTION
Listen to the ScreenSaver dbus signal to know when to stop the current activity.

Ideally it would backout the idle time before the screensaver cuts in, but I can't see any way to know if it cut in by idle activity or a key shortcut (in which case there should be no time backed out).

Frankly I was horrified that **the** most useful feature was removed from core. Without this I might as well track my time in a spreadsheet. After a week of time tracking frustration this is a 40 minute hack to solve the problem.

Take any or nothing of this as you please, I will not be offended. I'm not a js programmer nor ever hacked shell nor dbus before, so the fact that it worked at all was result enough for me. Putting the pull request up so others hopefully benefit. (Yes probably it needs a config option but I'll never turn it off so someone else is welcome to take that over.)

Thanks to all of the devs for hamster and extension so far, 10 years a happy user until the last upgrade!