### PR TITLE
Fix for 3.28

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -56,7 +56,7 @@ collect:
 	mkdir -p $(BUILDDIR)
 	cp -R extension/* $(BUILDDIR)
 	cp -R data/* $(BUILDDIR)
-	wget https://gitlab.gnome.org/GNOME/gnome-shell-extensions/raw/master/lib/convenience.js -O $(BUILDDIR)/convenience.js
+	wget https://gitlab.gnome.org/GNOME/gnome-shell-extensions/raw/gnome-3-28/lib/convenience.js -O $(BUILDDIR)/convenience.js
 
 compile: collect
 	glib-compile-schemas $(BUILDDIR)/schemas


### PR DESCRIPTION
It's not the right fix, however only note that for 3.28 URL is not working, needs to change it to https://gitlab.gnome.org/GNOME/gnome-shell-extensions/raw/gnome-3-28/lib/convenience.js