### PR TITLE
panelWidget: Do not override show() method

### DIFF
--- a/extension/extension.js
+++ b/extension/extension.js
@@ -183,7 +183,7 @@ class Controller {
 			      Meta.KeyBindingFlags.NONE,
 			      // Since Gnome 3.16, Shell.KeyBindingMode is replaced by Shell.ActionMode
 			      Shell.KeyBindingMode ? Shell.KeyBindingMode.ALL : Shell.ActionMode.ALL,
-			      this.panelWidget.toggle.bind(this.panelWidget)
+			      this.panelWidget.toggle_menu.bind(this.panelWidget)
 			     );
     }
 

--- a/extension/widgets/panelWidget.js
+++ b/extension/widgets/panelWidget.js
@@ -201,13 +201,6 @@ class PanelWidget extends PanelMenu.Button {
     }
 
     /**
-     * Open 'popup menu' containing the bulk of the extension widgets.
-     */
-    show() {
-        this.menu.open();
-    }
-
-    /**
      * Close/Open the 'popup menu' depending on previous state.
      */
     toggle() {

--- a/extension/widgets/panelWidget.js
+++ b/extension/widgets/panelWidget.js
@@ -203,7 +203,7 @@ class PanelWidget extends PanelMenu.Button {
     /**
      * Close/Open the 'popup menu' depending on previous state.
      */
-    toggle() {
+    toggle_menu() {
         this.menu.toggle();
     }
 


### PR DESCRIPTION
This widget defined a `show()` method, which would show the menu.
However, `show()` is already a method defined by some class higher up in
the hierarchy, which makes the *widget* in the status area visible.  By
defining a `show()` method here, the behavior of the `show()` method
changes, causing issues.

One such issue showed when combining this extension with the
status-area-horizontal-spacing extension, which calls `hide()` and
`show()` on each widget in the status area. With the overridden `show()`
method in the hamster extension, this would hide the widget and then
show the menu, breaking the extension because the widget would stay
hidden.

This commit renames `show()` to `show_menu()` to prevent to conflict.
It seems that the method was not actually used, so no references were
updated. For consistency, `toggle()` is also renamed to `toggle_menu()`,
with one reference updated.