### PR TITLE
Fix GNOME shell error message about factsBox.FactsBox

### DIFF
--- a/extension/widgets/factsBox.js
+++ b/extension/widgets/factsBox.js
@@ -43,7 +43,7 @@ const TodaysFactsWidget = Me.imports.widgets.todaysFactsWidget.TodaysFactsWidget
  * well as todays facts.
  * @class
  */
-const FactsBox = GObject.registerClass(
+var FactsBox = GObject.registerClass(
 class FactsBox extends PopupMenu.PopupBaseMenuItem {
     _init(controller, panelWidget) {
         super._init({reactive: false});


### PR DESCRIPTION
Fixes this error message:

gnome-shell[13339]: Some code accessed the property 'FactsBox' on the module
'factsBox'. That property was defined with 'let' or 'const' inside the
module. This was previously supported, but is not correct according to the ES6
standard. Any symbols to be exported from a module must be defined with
'var'. The property access will work as previously for the time being, but
please fix your code anyway.

This re-applies 36b07b4 ("Fix GNOME shell error message about
factsBox.FactsBox"), which seems to have been mistakenly removed by
the merge commit 801dddd.