### PR TITLE
display total time for the day

### DIFF
--- a/extension/widgets/factsBox.js
+++ b/extension/widgets/factsBox.js
@@ -35,6 +35,7 @@ const Me = imports.misc.extensionUtils.getCurrentExtension();
 const Stuff = Me.imports.stuff;
 const OngoingFactEntry = Me.imports.widgets.ongoingFactEntry.OngoingFactEntry;
 const CategoryTotalsWidget = Me.imports.widgets.categoryTotalsWidget.CategoryTotalsWidget;
+const TotalTimeWidget = Me.imports.widgets.totalTimeWidget.TotalTimeWidget;
 const TodaysFactsWidget = Me.imports.widgets.todaysFactsWidget.TodaysFactsWidget;
 
 
@@ -78,6 +79,10 @@ class FactsBox extends PopupMenu.PopupBaseMenuItem {
         // Setup category summery
         this.summaryLabel = new CategoryTotalsWidget();
         main_box.add(this.summaryLabel);
+
+        // Setup total time
+        this.totalTimeLabel = new TotalTimeWidget();
+        main_box.add(this.totalTimeLabel);
     }
 
     // [FIXME]
@@ -86,6 +91,7 @@ class FactsBox extends PopupMenu.PopupBaseMenuItem {
     // simpler version.
     refresh(facts, ongoingFact) {
         this.todaysFactsWidget.refresh(facts, ongoingFact);
+        this.totalTimeLabel.refresh(facts);
         this.summaryLabel.refresh(facts);
 
     }

--- a/extension/widgets/totalTimeWidget.js
+++ b/extension/widgets/totalTimeWidget.js
@@ -1,0 +1,65 @@
+/*
+This file is part of 'hamster-shell-extension'.
+
+'hamster-shell-extension' is free software: you can redistribute it and/or
+modify it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+'hamster-shell-extension' is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with 'hamster-shell-extension'.  If not, see <http://www.gnu.org/licenses/>.
+
+Copyright (c) 2011 Jerome Oufella <jerome@oufella.com>
+Copyright (c) 2011-2012 Toms Baugis <toms.baugis@gmail.com>
+Icons Artwork Copyright (c) 2012 Reda Lazri <the.red.shortcut@gmail.com>
+Copyright (c) 2016 - 2018 Eric Goller / projecthamster <elbenfreund@projecthamster.org>
+Copyright (c) 2018 Thibaut Madelaine <madtibo_git@tribu-ml.fr>
+*/
+
+
+const Lang = imports.lang;
+const St = imports.gi.St;
+const Clutter = imports.gi.Clutter;
+const GLib = imports.gi.GLib;
+
+const Me = imports.misc.extensionUtils.getCurrentExtension();
+const Stuff = Me.imports.stuff;
+
+
+/**
+ * Custom Label widget that displays total time.
+ */
+var TotalTimeWidget = new Lang.Class({
+    Name: 'TotalTime',
+    Extends: St.Label,
+
+    _init: function() {
+        this.parent({style_class: 'summary-label'});
+
+    },
+
+    /**
+     * Recompute values and replace old string with new one based on passed facts.
+     */
+    refresh: function(facts) {
+        /**
+         * Construct a string representing today total.
+         */
+        function getString(facts) {
+            let totalTime = 0;
+            for (let fact of facts) {
+                totalTime += fact.delta;
+            }
+
+            let string = "Total: " + Stuff.formatDurationHours(totalTime);
+            return string;
+        }
+
+        this.set_text(getString(facts));
+    },
+});


### PR DESCRIPTION
Add a new label displaying the total time below the per-category
sums.

This is rebased version of @madtibo's PR #297. As @madtibo said [he isn't using the extension any more](https://github.com/projecthamster/hamster-shell-extension/pull/297#issuecomment-838023898), I'm cloning his PR here.