### PR TITLE
Default shortcut Super+t

### DIFF
--- a/data/schemas/org.gnome.shell.extensions.project-hamster.gschema.xml
+++ b/data/schemas/org.gnome.shell.extensions.project-hamster.gschema.xml
@@ -14,7 +14,7 @@
         </key>
 
         <key type="as" name="show-hamster-dropdown">
-            <default><![CDATA[['<Super>h']]]></default>
+            <default><![CDATA[['<Super>t']]]></default>
             <summary>Global key combination to show the drop-down.</summary>
         </key>
     </schema>


### PR DESCRIPTION
Change the default shortcut from <kbd>Super</kbd>+<kbd>h</kbd> to <kbd>Super</kbd>+<kbd>t</kbd> to avoid conflicts with the shortcut for _Gnome minimize window_

Fixes #286
Possibly fixes #282 ([since changing the shortcut key combo [...] I haven't had a single crash.](https://github.com/projecthamster/hamster-shell-extension/issues/282#issuecomment-395314756))