### PR TITLE
WIP: stop tracking when destroy signal is received

### DIFF
--- a/extension/widgets/panelWidget.js
+++ b/extension/widgets/panelWidget.js
@@ -196,7 +196,9 @@ class PanelWidget extends PanelMenu.Button {
     // This should really be a synchronous call fetching the facts.
     // Once this is done, the actual code from the callback should follow
     // here.
-    this._controller.apiProxy.GetTodaysFactsRemote(_refresh.bind(this));
+    if (this._controller.apiProxy) {
+        this._controller.apiProxy.GetTodaysFactsRemote(_refresh.bind(this));
+    }
     return GLib.SOURCE_CONTINUE;
     }
 
@@ -268,6 +270,7 @@ class PanelWidget extends PanelMenu.Button {
      */
     _disableRefreshTimer() {
         GLib.source_remove(this.timeout);
+        this._onStopTracking();
     }
 
     /**


### PR DESCRIPTION
When the destroy signal is received and the gnome extension is disabled, e.g., by locking the screen, it is safe to assume that the current activity can be stopped.

Fixes #354

**How to test**:
1. Start tracking an activity
2. Lock the gnome-session
3. Unlock the gnome-session
4. Verify that no activity is being tracked