### PR TITLE
Add Gnome Shell 44 compatibility

### DIFF
--- a/data/metadata.json.in
+++ b/data/metadata.json.in
@@ -16,7 +16,8 @@
         "40",
         "41",
         "42",
-        "43"
+        "43",
+        "44"
     ],
     "url": "https://github.com/projecthamster/hamster-shell-extension.git",
     "uuid": @UUID@


### PR DESCRIPTION
- [Upgrading guide](https://gjs.guide/extensions/upgrading/gnome-shell-44.html#gsettings-schema)
- [x] needs testing (Tested it with Ubuntu 23.04)