### PR TITLE
Gracefully handle hamster restarts for development

### DIFF
--- a/extension/extension.js
+++ b/extension/extension.js
@@ -148,23 +148,21 @@ class Controller {
 
         // Callbacks that handle appearing/vanishing dbus services.
         function apiProxy_appeared_callback() {
+            if (this.shouldEnable)
+                this.panelWidget.show();
         }
 
         function apiProxy_vanished_callback() {
 	    /* jshint validthis: true */
-            global.log(_("hamster-shell-extension: 'hamster-service' not running. Shutting down."));
-            Main.notify(_("hamster-shell-extension: 'hamster-service' not running. Shutting down."));
-            this.disable();
+            this.reportIfError(_("DBUS proxy disappeared"), _("Disabling extension until it comes back"));
+            if (this.shouldEnable)
+                this.panelWidget.hide();
         }
 
         function windowsProxy_appeared_callback() {
         }
 
         function windowsProxy_vanished_callback() {
-	    /* jshint validthis: true */
-            global.log(_("hamster-shell-extension: 'hamster-windows-service' not running. Shutting down."));
-            Main.notify(_("hamster-shell-extension: 'hamster-windows-service' not running. Shutting down."));
-            this.disable();
         }
 
         // Set-up watchers that watch for required dbus services.

--- a/extension/extension.js
+++ b/extension/extension.js
@@ -210,10 +210,28 @@ class Controller {
 
         this.runningActivitiesQuery = true;
         this.apiProxy.GetActivitiesRemote("", function([response], err) {
+            this.reportIfError(_("Failed to get activities"), err);
             this.runningActivitiesQuery = false;
             this.activities = response;
             // global.log('ACTIVITIES HAMSTER: ', this.activities);
         }.bind(this));
+    }
+
+    /**
+     * Report an error if one is passed. If error is falsey (e.g.
+     * null), nothing is reported.
+     */
+    reportIfError(msg, error) {
+        if (error) {
+            // Use toString, error can be a string, exception, etc.
+            global.log("error: Hamster: " + msg + ": " + error.toString());
+            // Prefix msg to details (second argument), since the
+            // details are word-wrapped and the title is not.
+            Main.notify("Hamster: " + msg, msg + "\n" + error.toString());
+            // Close menu so notification can be seen
+            if (this.panelWidget)
+                this.panelWidget.close_menu();
+        }
     }
 
     /**

--- a/extension/extension.js
+++ b/extension/extension.js
@@ -120,13 +120,15 @@ class Controller {
     enable() {
         this.shouldEnable = true;
         new ApiProxy(Gio.DBus.session, 'org.gnome.Hamster', '/org/gnome/Hamster',
-                     function(proxy) {
+                     function(proxy, err) {
+                         this.reportIfError(_("Connection to DBUS service failed"), err);
 			 this.apiProxy = proxy;
 			 this.deferred_enable();
                      }.bind(this));
         new WindowsProxy(Gio.DBus.session, "org.gnome.Hamster.WindowServer",
 			 "/org/gnome/Hamster/WindowServer",
-			 function(proxy) {
+			 function(proxy, err) {
+                             this.reportIfError(_("Connection to DBUS window service failed"), err);
 			     this.windowsProxy = proxy;
 			     this.deferred_enable();
 			 }.bind(this));

--- a/extension/widgets/ongoingFactEntry.js
+++ b/extension/widgets/ongoingFactEntry.js
@@ -71,6 +71,7 @@ class OngoingFactEntry extends St.Entry {
     _onEntryActivated() {
         let text = this.get_text();
         this._controller.apiProxy.AddFactRemote(text, 0, 0, false, function(response, error) {
+            this._controller.reportIfError(_("Failed to add activity"), error);
             // not interested in the new id - this shuts up the warning
 	}.bind(this));
         this.set_text('');

--- a/extension/widgets/panelWidget.js
+++ b/extension/widgets/panelWidget.js
@@ -178,10 +178,8 @@ class PanelWidget extends PanelMenu.Button {
 
 		let facts = [];
 
-        // [FIXME]
-        // This seems a rather naive way to handle potential errors.
 		if (err) {
-		    log(err);
+                    this._controller.reportIfError(_("Failed to get activities"), err);
 		} else if (response.length > 0) {
 		    facts = Stuff.fromDbusFacts(response);
 		}
@@ -207,6 +205,12 @@ class PanelWidget extends PanelMenu.Button {
         this.menu.toggle();
     }
 
+    /**
+     * Close the 'popup menu'
+     */
+    close_menu() {
+        this.menu.close();
+    }
 
     /**
      * Update the rendering of the PanelWidget in the panel itself.
@@ -286,7 +290,9 @@ class PanelWidget extends PanelMenu.Button {
                                     now.getMinutes(),
                                     now.getSeconds());
         epochSeconds = Math.floor(epochSeconds / 1000);
-        this._controller.apiProxy.StopTrackingRemote(GLib.Variant.new('i', [epochSeconds]));
+        this._controller.apiProxy.StopTrackingRemote(GLib.Variant.new('i', [epochSeconds]), function(response, err) {
+            this._controller.reportIfError(_("Failed to stop tracking"), err);
+        }.bind(this));
     }
 
     /**
@@ -295,7 +301,11 @@ class PanelWidget extends PanelMenu.Button {
      * @callback panelWidget~_onOpenOverview
      */
     _onOpenOverview() {
-        this._controller.windowsProxy.overviewSync();
+        try {
+            this._controller.windowsProxy.overviewSync();
+        } catch (error) {
+            this._controller.reportIfError(_("Failed to open overview window"), error);
+        }
     }
 
     /**
@@ -304,7 +314,11 @@ class PanelWidget extends PanelMenu.Button {
      * @callback panelWidget~_onOpenAddFact
      */
     _onOpenAddFact() {
-        this._controller.windowsProxy.editSync(GLib.Variant.new('i', [0]));
+        try {
+            this._controller.windowsProxy.editSync(GLib.Variant.new('i', [0]));
+        } catch (error) {
+            this._controller.reportIfError(_("Failed to open add window"), error);
+        }
     }
 
     /**
@@ -315,6 +329,10 @@ class PanelWidget extends PanelMenu.Button {
      * Note: This will open the GUI settings, not the extension settings!
      */
     _onOpenSettings() {
-        this._controller.windowsProxy.preferencesSync();
+        try {
+            this._controller.windowsProxy.preferencesSync();
+        } catch (error) {
+            this._controller.reportIfError(_("Failed to open settings window"), error);
+        }
     }
 });

--- a/extension/widgets/todaysFactsWidget.js
+++ b/extension/widgets/todaysFactsWidget.js
@@ -26,6 +26,9 @@ const Clutter = imports.gi.Clutter;
 const GLib = imports.gi.GLib;
 const GObject = imports.gi.GObject;
 
+const Gettext = imports.gettext.domain('hamster-shell-extension');
+const _ = Gettext.gettext;
+
 const Me = imports.misc.extensionUtils.getCurrentExtension();
 const Stuff = Me.imports.stuff;
 
@@ -114,6 +117,7 @@ class TodaysFactsWidget extends St.ScrollView {
 
 		/* jshint validthis: true */
                 controller.apiProxy.AddFactRemote(factStr, 0, 0, false, function(response, err) {
+                    controller.reportIfError(_("Failed to continue activity"), err);
                     // not interested in the new id - this shuts up the warning
                 }.bind(this));
                 menu.close();


### PR DESCRIPTION
This changes the code to more gracefully handle a hamster restart. Previously it would try to disable itself and then run into an error. Now it hides the panel item and shows it again when hamster is started again. The implementation is not perfect (see commit message for some rough edges), but that's ok since users normally have no need (or even a good way) to restart the hamster services, so this change mostly serves to make development easier.

In addition, I've preceded this change with two more commits that improve error handling for dbus calls. This was prompted because one of the rough edges is that you can now technically end up in a situation where the extension is shown and usable, but the windows service is not running, so clicking e.g. "Show Overview" will not work. That will now show an error to the user, which should make this an acceptable corner case. However, showing error messages when a dbus call fails seems an improvement in general too (for example, this now also shows an error for the case in #334  - though the python backtrace is so long the actual error message is cropped, at least it shows something at least - and the log shows the full error).