### PR TITLE
metadata.json: Mark compatible with GNOME Shell 47

### DIFF
--- a/data/metadata.json.in
+++ b/data/metadata.json.in
@@ -11,7 +11,8 @@
     "settings-schema": "org.gnome.shell.extensions.project-hamster",
     "shell-version": [
       "45",
-      "46"
+      "46",
+      "47"
     ],
     "url": "https://github.com/projecthamster/hamster-shell-extension.git",
     "uuid": @UUID@


### PR DESCRIPTION
GNOME 47 is scheduled for release on Wednesday.

I did a very simple smoketest with this change on Debian with gnome-shell 47.rc

See also https://gjs.guide/extensions/upgrading/gnome-shell-47.html