### PR TITLE
metadata.json.in: mark GNOME 47 supported

### DIFF
--- a/data/metadata.json.in
+++ b/data/metadata.json.in
@@ -11,7 +11,8 @@
     "settings-schema": "org.gnome.shell.extensions.project-hamster",
     "shell-version": [
       "45",
-      "46"
+      "46",
+      "47"
     ],
     "url": "https://github.com/projecthamster/hamster-shell-extension.git",
     "uuid": @UUID@


### PR DESCRIPTION
Works well for me under GNOME 47.