### PR TITLE
Add option to hide the daily activity summary

### DIFF
--- a/data/schemas/org.gnome.shell.extensions.project-hamster.gschema.xml
+++ b/data/schemas/org.gnome.shell.extensions.project-hamster.gschema.xml
@@ -13,6 +13,12 @@
             <description>Sets the panel appearance. 0 - label, 1 - icon, 2 - label and icon.</description>
         </key>
 
+        <key name="show-summary" type="b">
+            <default>true</default>
+            <summary>Display categories summary.</summary>
+            <description>Whether to display a summary of today's categories.</description>
+        </key>
+
         <key type="as" name="show-hamster-dropdown">
             <default><![CDATA[['<Super>t']]]></default>
             <summary>Global key combination to show the drop-down.</summary>

--- a/extension/widgets/factsBox.js
+++ b/extension/widgets/factsBox.js
@@ -71,9 +71,13 @@ class FactsBox extends PopupMenu.PopupBaseMenuItem {
         this._scrollAdjustment = this.todaysFactsWidget.vscroll.adjustment;
         main_box.add_child(this.todaysFactsWidget);
 
+        this._settings = controller.settings;
+
         // Setup category summery
-        this.summaryLabel = new CategoryTotalsWidget();
-        main_box.add_child(this.summaryLabel);
+        if (this._settings.get_boolean("show-summary")) {
+            this.summaryLabel = new CategoryTotalsWidget();
+            main_box.add_child(this.summaryLabel);
+        }
         // Setup total time
         this.totalTimeLabel = new TotalTimeWidget();
         main_box.add_child(this.totalTimeLabel);
@@ -86,7 +90,9 @@ class FactsBox extends PopupMenu.PopupBaseMenuItem {
     refresh(facts, ongoingFact) {
         this.todaysFactsWidget.refresh(facts, ongoingFact);
         this.totalTimeLabel.refresh(facts);
-        this.summaryLabel.refresh(facts);
+        if (this._settings.get_boolean("show-summary")) {
+            this.summaryLabel.refresh(facts);
+        }
 
     }
 


### PR DESCRIPTION
Currently, after working on a few different activities in a day, the "daily summary" expands in width, pushing the start of the activity field off the screen.

This PR adds a dconf-only option (no UI yet) to hide the activity completely, to work around this issue.

A better fix might be to make the summary flow onto multiple lines; I went with an option to hide it instead because it seemed easier – and I'm fine launching hamster if I want to see the summary.