### PR TITLE
Make hamster-shell-extension compatible with GNOME 48

### DIFF
--- a/data/metadata.json.in
+++ b/data/metadata.json.in
@@ -10,7 +10,6 @@
     "gettext-domain": "hamster-shell-extension",
     "settings-schema": "org.gnome.shell.extensions.project-hamster",
     "shell-version": [
-      "45",
       "46",
       "47",
       "48"

--- a/data/metadata.json.in
+++ b/data/metadata.json.in
@@ -12,7 +12,8 @@
     "shell-version": [
       "45",
       "46",
-      "47"
+      "47",
+      "48"
     ],
     "url": "https://github.com/projecthamster/hamster-shell-extension.git",
     "uuid": @UUID@

--- a/extension/widgets/factsBox.js
+++ b/extension/widgets/factsBox.js
@@ -68,7 +68,6 @@ class FactsBox extends PopupMenu.PopupBaseMenuItem {
         // Since ``St.Table`` does not implement St.Scrollable, we create a
         // container object that does.
         this.todaysFactsWidget = new TodaysFactsWidget(this._controller, panelWidget);
-        this._scrollAdjustment = this.todaysFactsWidget.vscroll.adjustment;
         main_box.add_child(this.todaysFactsWidget);
 
         // Setup category summery
@@ -95,7 +94,8 @@ class FactsBox extends PopupMenu.PopupBaseMenuItem {
      */
     focus() {
         GLib.timeout_add(GLib.PRIORITY_DEFAULT, 20, function() {
-            this._scrollAdjustment.value = this._scrollAdjustment.upper;
+            let _vAdjustment = this.todaysFactsWidget.vadjustment;
+            _vAdjustment.value = _vAdjustment.upper;
             global.stage.set_key_focus(this.ongoingFactEntry);
         }.bind(this));
     }


### PR DESCRIPTION
Don't use the "vscroll" property which has been removed in GNOME 48 after having been deprecated in GNOME 46. Instead rely on the "vadjustment" property.

Fixes #375