### PR TITLE
Use Clutter.Actor.add_child instead of add_actor

### DIFF
--- a/extension/widgets/todaysFactsWidget.js
+++ b/extension/widgets/todaysFactsWidget.js
@@ -49,11 +49,7 @@ class TodaysFactsWidget extends St.ScrollView {
             reactive: true
         });
         this.factsBox.add_child(this.facts_widget);
-        if (Config.PACKAGE_VERSION.substring(0, 2) == "45")
-            this.add_actor(this.factsBox);
-        else
-            this.add_child(this.factsBox);
-
+        this.add_child(this.factsBox);
     }
 
     /**


### PR DESCRIPTION
The add_actor is removed in gnome 48. See https://gjs-docs.gnome.org/clutter13~13/clutter.container#method-add_actor for details. Tested on Fedora 42.