### PR TITLE
ongoingFactEntry: Remove custom style class

### DIFF
--- a/extension/widgets/ongoingFactEntry.js
+++ b/extension/widgets/ongoingFactEntry.js
@@ -42,8 +42,7 @@ class OngoingFactEntry extends St.Entry {
             name: 'searchEntry',
             can_focus: true,
             track_hover: true,
-            hint_text: _("Enter activity…"),
-            style_class: "search-entry"
+            hint_text: _("Enter activity…")
         });
 
         this._controller = controller;


### PR DESCRIPTION
This fixes the "Enter activity.." text input to actually be usable and visible on my Ubuntu 24.04 (GNOME 46) when using light mode.

In dark mode having the extra style class seems to work fine, but in light mode the input field is a light color and the text is also almost in the same color, so you cannot see what you write.

With the fix:

<img width="2880" height="1800" alt="Screenshot from 2025-08-08 11-11-50" src="https://github.com/user-attachments/assets/c1662246-c22a-424e-b093-681db1e0a9da" />

Without the fix:

<img width="2880" height="1800" alt="Screenshot from 2025-08-08 11-13-39" src="https://github.com/user-attachments/assets/43ae525b-7fdb-46f4-a250-bb2d059a8e1c" />
