### PR TITLE
Mark GNOME 50 supported

### DIFF
--- a/data/metadata.json.in
+++ b/data/metadata.json.in
@@ -13,7 +13,8 @@
       "46",
       "47",
       "48",
-      "49"
+      "49",
+      "50"
     ],
     "url": "https://github.com/projecthamster/hamster-shell-extension.git",
     "uuid": @UUID@


### PR DESCRIPTION
The extension runs on my system under GNOME 50 without problems and error messages.